### PR TITLE
feat: add mouse Y-axis invert toggle in settings

### DIFF
--- a/src/config.tsx
+++ b/src/config.tsx
@@ -16,5 +16,5 @@ export const THEMES = {
 export const CONFIG = {
     // Port for the Vite Frontend
     FRONTEND_PORT: serverConfig.frontendPort,
-    MOUSE_Y_INVERT: serverConfig.MOUSE_Y_INVERT ?? false
+    MOUSE_INVERT: serverConfig.mouseInvert ?? false
 };

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/settings')({
 function SettingsPage() {
     const [ip, setIp] = useState('');
     const [frontendPort, setFrontendPort] = useState(String(CONFIG.FRONTEND_PORT));
-    const [invertScroll, setInvertScroll] = useState(CONFIG.MOUSE_Y_INVERT);
+    const [invertScroll, setInvertScroll] = useState(CONFIG.MOUSE_INVERT);
     const [qrData, setQrData] = useState('');
 
     // Load initial state
@@ -103,7 +103,7 @@ function SettingsPage() {
 
                 <div className="form-control w-full">
                     <label className="label cursor-pointer">
-                        <span className="label-text font-medium">Invert Scroll (Y-axis)</span>
+                        <span className="label-text font-medium">Invert Scroll</span>
                         <input
                             type="checkbox"
                             className="toggle toggle-primary"
@@ -111,7 +111,7 @@ function SettingsPage() {
                             onChange={(e) => setInvertScroll(e.target.checked)}
                         />
                     </label>
-                    <br />  
+                    <br />
                     <label className="label">
                         <span className="label-text-alt opacity-50">
                             {invertScroll ? 'Traditional scrolling enabled' : 'Natural scrolling'}
@@ -150,7 +150,7 @@ function SettingsPage() {
                                 type: 'update-config',
                                 config: {
                                     frontendPort: parseInt(frontendPort),
-                                    MOUSE_Y_INVERT: invertScroll
+                                    mouseInvert: invertScroll
                                 }
                             }));
 

--- a/src/server-config.json
+++ b/src/server-config.json
@@ -2,5 +2,5 @@
   "host": "0.0.0.0",
   "frontendPort": 3000,
   "address": "rein.local",
-  "MOUSE_Y_INVERT": false
+  "mouseInvert": true
 }

--- a/src/server/InputHandler.ts
+++ b/src/server/InputHandler.ts
@@ -1,6 +1,6 @@
 import { mouse, Point, Button, keyboard } from '@nut-tree-fork/nut-js';
 import { KEY_MAP } from './KeyMap';
-import serverConfig from '../server-config.json';
+import { CONFIG } from '../config';
 
 export interface InputMessage {
     type: 'move' | 'click' | 'scroll' | 'key' | 'text';
@@ -38,9 +38,9 @@ export class InputHandler {
                 break;
 
             case 'scroll':
-                const invertMultiplier = (serverConfig.MOUSE_Y_INVERT ?? false) ? -1 : 1;
+                const invertMultiplier = (CONFIG.MOUSE_INVERT ?? false) ? -1 : 1;
                 if (msg.dy !== undefined && msg.dy !== 0) await mouse.scrollDown(msg.dy * invertMultiplier);
-                if (msg.dx !== undefined && msg.dx !== 0) await mouse.scrollRight(msg.dx);
+                if (msg.dx !== undefined && msg.dx !== 0) await mouse.scrollRight(msg.dx * -1 * invertMultiplier);
                 break;
 
             case 'key':


### PR DESCRIPTION
Added a toggle in Settings to invert mouse Y-axis scrolling direction (natural vs traditional scrolling).

Changes

Added "Invert Scroll (Y-axis)" toggle using DaisyUI component (toggle toggle-primary)

Applied inversion multiplier to scroll events in InputHandler.ts

Setting saves to JSON and persists across server restarts

Testing
Verified scroll direction inverts correctly when enabled
Confirmed setting persists after server restart
looks same on mobile and desktop
<img width="1866" height="984" alt="image" src="https://github.com/user-attachments/assets/be9df2aa-134e-423a-a519-c96092a18282" />

<img width="585" height="1266" alt="IMG_8378" src="https://github.com/user-attachments/assets/4a99478f-8f08-442b-a6e0-b58b14e11409" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Invert Scroll" setting on the Settings page to switch between traditional and natural scrolling.
  * Toggle shows a live status label indicating the current scroll mode.
  * Preference is saved so the chosen scroll behavior persists across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->