### PR TITLE
fix: remove IP from client-side storage; store only sensitivity, invert, theme

### DIFF
--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -31,12 +31,10 @@ function SettingsPage() {
 
     const [qrData, setQrData] = useState('');
 
-    // Load initial state
+    // Load initial state (IP is not stored in localStorage; only sensitivity, invert, theme are client settings)
     useEffect(() => {
-        const storedIp = localStorage.getItem('rein_ip');
         const defaultIp = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
-
-        setIp(storedIp || defaultIp);
+        setIp(defaultIp);
         setFrontendPort(String(CONFIG.FRONTEND_PORT));
     }, []);
 
@@ -49,20 +47,15 @@ function SettingsPage() {
         localStorage.setItem('rein_invert', JSON.stringify(invertScroll));
     }, [invertScroll]);
 
-    // Effect: Update LocalStorage and Generate QR
+    // Generate QR when IP changes (IP is not persisted to localStorage)
     useEffect(() => {
-        if (!ip) return;
-        localStorage.setItem('rein_ip', ip);
-
-        if (typeof window !== 'undefined') {
-            const appPort = String(CONFIG.FRONTEND_PORT);
-            const protocol = window.location.protocol;
-            const shareUrl = `${protocol}//${ip}:${appPort}/trackpad`;
-
-            QRCode.toDataURL(shareUrl)
-                .then(setQrData)
-                .catch((e) => console.error('QR Error:', e));
-        }
+        if (!ip || typeof window === 'undefined') return;
+        const appPort = String(CONFIG.FRONTEND_PORT);
+        const protocol = window.location.protocol;
+        const shareUrl = `${protocol}//${ip}:${appPort}/trackpad`;
+        QRCode.toDataURL(shareUrl)
+            .then(setQrData)
+            .catch((e) => console.error('QR Error:', e));
     }, [ip]);
 
     // Effect: Auto-detect LAN IP from Server (only if on localhost)


### PR DESCRIPTION
Fixes #68

## Summary
Client-side settings (localStorage) now persist only **mouse sensitivity**, **invert scroll**, and **theme**. The Server IP (for Remote) is no longer read from or written to localStorage.

## Changes
- **settings.tsx:** Removed `localStorage.getItem('rein_ip')` on load; IP is initialized from `window.location.hostname` only. Removed `localStorage.setItem('rein_ip', ip)` when IP changes. QR code still updates from current IP state; IP is simply not persisted across sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated IP address initialization logic in settings
  * Optimized QR code generation mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->