### PR TITLE
fix: remove 250ms movement lockout and refactor gesture handling

### DIFF
--- a/src/hooks/useTrackpadGesture.ts
+++ b/src/hooks/useTrackpadGesture.ts
@@ -39,7 +39,6 @@ export const useTrackpadGesture = (
     const findTouchIndex = (id: number) => ongoingTouches.current.findIndex(t => t.identifier === id);
 
     const processMovement = (sumX: number, sumY: number) => {
-        // Active drag always sends move events regardless of mode
         if (dragging.current) {
             send({ 
                 type: 'move', 
@@ -48,13 +47,10 @@ export const useTrackpadGesture = (
             });
             return;
         }
-
         const invertMult = invertScroll ? -1 : 1;
-
         if (!scrollMode && ongoingTouches.current.length === 2) {
             const dist = getTouchDistance(ongoingTouches.current[0], ongoingTouches.current[1]);
             const delta = lastPinchDist.current !== null ? dist - lastPinchDist.current : 0;
-            
             if (pinching.current || Math.abs(delta) > PINCH_THRESHOLD) {
                 pinching.current = true;
                 lastPinchDist.current = dist;
@@ -70,7 +66,6 @@ export const useTrackpadGesture = (
         } else if (scrollMode || ongoingTouches.current.length === 2) {
             let scrollDx = sumX;
             let scrollDy = sumY;
-            
             if (scrollMode) {
                 const absDx = Math.abs(scrollDx);
                 const absDy = Math.abs(scrollDy);
@@ -86,7 +81,6 @@ export const useTrackpadGesture = (
                 dy: Math.round(-scrollDy * sensitivity * 10 * invertMult) / 10 
             });
         } else if (ongoingTouches.current.length === 1) {
-            // Cursor movement (only in cursor mode with 1 finger)
             send({ 
                 type: 'move', 
                 dx: Math.round(sumX * sensitivity * 10) / 10, 


### PR DESCRIPTION
Closes #76 

### Overview
The trackpad previously felt laggy or "stuck" during rapid swipes and multi-touch transitions due to an artificial 250ms lockout period.

### Changes
- **Fixed Movement Lag**: Removed the redundant `lastEndTimeStamp` check in `handleTouchMove`. This check was blocking all movement events for 250ms every time a finger was lifted, causing noticeable input delay.
- **Refactored Gesture Logic**: Abstracted the message-sending logic into a new `processMovement` helper function. This makes the code more readable and easier to maintain without changing the core behavior.
- **Cleanup**: Removed the now-obsolete `lastEndTimeStamp` reference and its associated logic to keep the hook clean and focused.

### Technical Rationale
The `moved.current` flag already correctly handles the distinction between a "Tap" and a "Move" based on touch distance and initial duration. The additional timestamp check created a blackout period that interrupted the coordinate stream, especially during fluid gestures like two-finger scrolling. Removing this restores natural, real-time responsiveness.

### Verification Results
- Tested rapid swiping: Cursor responds immediately without the previous "dead zone."
- Tested multi-touch transitions: Lifting one finger during a scroll no longer freezes the remaining input.
- Verified tap-to-click: Still works as expected since the distance-based logic remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled touch gesture handling to route movements through a unified processing flow, improving consistency for drag, pinch/zoom, and two-finger scroll interactions.
* **Bug Fixes**
  * Reduced missed or delayed movement recognition and removed time-based gating, yielding more responsive and reliable tap/click, drag, scroll, and pinch behaviors on touch devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->