### PR TITLE
Fix: Prevent stored buffer resend on backspace (#96)

### DIFF
--- a/src/server/InputHandler.ts
+++ b/src/server/InputHandler.ts
@@ -93,19 +93,25 @@ export class InputHandler {
                 }
                 break;
 
-            case 'key':
-                if (msg.key) {
-                    console.log(`Processing key: ${msg.key}`);
-                    const nutKey = KEY_MAP[msg.key.toLowerCase()];
-                    if (nutKey !== undefined) {
-                        await keyboard.type(nutKey);
-                    } else if (msg.key.length === 1) {
-                        await keyboard.type(msg.key);
-                    } else {
-                        console.log(`Unmapped key: ${msg.key}`);
-                    }
-                }
-                break;
+    case 'key':
+    if (msg.key) {
+        console.log(`Processing key: ${msg.key}`);
+        const lowerKey = msg.key.toLowerCase();
+        const nutKey = KEY_MAP[lowerKey];
+
+        if (nutKey !== undefined) {
+            await keyboard.pressKey(nutKey);
+            await keyboard.releaseKey(nutKey);
+        } 
+        else if (msg.key.length === 1) {
+            await keyboard.type(msg.key);
+        } 
+        else {
+            console.log(`Unmapped key: ${msg.key}`);
+        }
+    }
+    break;
+
 
             case 'combo':
                 if (msg.keys && msg.keys.length > 0) {
@@ -151,11 +157,12 @@ export class InputHandler {
                 }
                 break;
 
-            case 'text':
-                if (msg.text) {
-                    await keyboard.type(msg.text);
-                }
-                break;
+           case 'text':
+    if (msg.text && msg.text.length === 1) {
+        await keyboard.type(msg.text);
+    }
+    break;
+
         }
     }
 }


### PR DESCRIPTION
Fixes #96

When pressing Backspace, the previously stored input buffer was being re-sent before the deletion occurred. This caused:
Duplicate text to appear
Previous full message to be retyped
Noticeable delay before character deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced keyboard input handling with proper key press and release sequences
  * Refined text input validation for single character processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->