### PR TITLE
fix: resolve keyboard/IME buffer interference on mobile (#121)

### DIFF
--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -18,6 +18,8 @@ function TrackpadPage() {
     const [buffer, setBuffer] = useState<string[]>([]);
     const bufferText = buffer.join(" + ");
     const hiddenInputRef = useRef<HTMLInputElement>(null);
+    const isComposingRef = useRef(false);
+    const prevCompositionDataRef = useRef('');
 
     // Load Client Settings
     const [sensitivity] = useState(() => {
@@ -46,7 +48,67 @@ function TrackpadPage() {
         setTimeout(() => send({ type: 'click', button, press: false }), 50);
     };
 
+    const processCompositionDiff = (currentData: string, prevData: string) => {
+        if (currentData === prevData) return;
+
+        // Find common prefix length
+        let commonLen = 0;
+        while (
+            commonLen < prevData.length &&
+            commonLen < currentData.length &&
+            prevData[commonLen] === currentData[commonLen]
+        ) {
+            commonLen++;
+        }
+
+        // Send backspaces for removed/changed characters
+        const deletions = prevData.length - commonLen;
+        for (let i = 0; i < deletions; i++) {
+            send({ type: 'key', key: 'backspace' });
+        }
+
+        // Send new characters individually
+        const newChars = currentData.slice(commonLen);
+        for (const char of newChars) {
+            if (modifier !== "Release") {
+                handleModifier(char);
+            } else {
+                send({ type: 'text', text: char });
+            }
+        }
+    };
+
+    const handleCompositionStart = () => {
+        isComposingRef.current = true;
+        prevCompositionDataRef.current = '';
+    };
+
+    const handleCompositionUpdate = (e: React.CompositionEvent<HTMLInputElement>) => {
+        const currentData = e.data || '';
+        processCompositionDiff(currentData, prevCompositionDataRef.current);
+        prevCompositionDataRef.current = currentData;
+    };
+
+    const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+        const currentData = e.data || '';
+        processCompositionDiff(currentData, prevCompositionDataRef.current);
+        prevCompositionDataRef.current = '';
+
+        // Clear input to prevent buffer accumulation
+        if (hiddenInputRef.current) {
+            hiddenInputRef.current.value = '';
+        }
+
+        // Delay flag reset so the onChange firing after compositionend is suppressed
+        setTimeout(() => {
+            isComposingRef.current = false;
+        }, 0);
+    };
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        // Skip during IME composition — composition handlers manage input
+        if (e.nativeEvent.isComposing || isComposingRef.current) return;
+
         const key = e.key.toLowerCase();
 
         if (modifier !== "Release") {
@@ -115,6 +177,7 @@ function TrackpadPage() {
     };
 
     const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (isComposingRef.current) return; // Skip during IME composition
         const val = e.target.value;
         if (val) {
             e.target.value = '';
@@ -175,13 +238,17 @@ function TrackpadPage() {
                 className="opacity-0 absolute bottom-0 pointer-events-none h-0 w-0"
                 onKeyDown={handleKeyDown}
                 onChange={handleInput}
+                onCompositionStart={handleCompositionStart}
+                onCompositionUpdate={handleCompositionUpdate}
+                onCompositionEnd={handleCompositionEnd}
                 onBlur={() => {
                     setTimeout(() => hiddenInputRef.current?.focus(), 10);
                 }}
                 autoComplete="off"
                 autoCorrect="off"
                 autoCapitalize="off"
-                autoFocus // Attempt autofocus on mount
+                spellCheck={false}
+                autoFocus
             />
         </div>
     )


### PR DESCRIPTION
## Addressed Issues:
Fixes #121

## Description
When typing on mobile, the keyboard's IME was accumulating characters in an internal buffer. On backspace the IME would flush the entire buffer back through `onChange` causing repeated incorrect text input

This fix intercepts IME composition events directly computes character level diffs to send only incremental changes

### Changes:
- Add `compositionstart`/`compositionupdate`/`compositionend` handlers to intercept IME input
- Track composition state with `isComposingRef` to suppress `onChange` during active composition  
- Compute diffs between composition states to send only new chars or backspaces
- Skip `keyDown` processing during composition to avoid duplicate input
- Clear input value on `compositionEnd` to prevent buffer accumulation
- Add `spellCheck={false}` to hidden input

## Screenshots/Recordings:
N/A
<img width="1273" height="785" alt="Screenshot 2026-02-19 at 20 59 54" src="https://github.com/user-attachments/assets/99417633-1e1e-4e8c-9b1b-cdaa34c1f2fc" />

https://github.com/user-attachments/assets/3dff565e-eb1c-4f80-ae6b-f4193781ad36


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Functional Verification
- [x] Keyboard input: Verified Space, Backspace, and Enter keys work correctly.

## Tested on
- Samsung Note 10 Plus (Android) — verified all three test scenarios pass:
  1. Basic typing sends individual characters without buffer leak
  2. Backspace sends single backspace command without IME replaying previous text
  3. Rapid type-then-delete works cleanly with no phantom characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Input Method Editor (IME) composition handling for better support of non-Latin character input. Enhanced composition state tracking and input buffer management for more reliable text composition during character entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->