### PR TITLE
feat:  Add PIN-Based Authentication for LAN Clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -521,6 +522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -561,6 +563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1075,6 +1078,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
       "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/core": "^0.22.12"
       }
@@ -1111,6 +1115,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
       "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -1123,6 +1128,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
       "integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -1147,6 +1153,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
       "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12",
         "tinycolor2": "^1.6.0"
@@ -1190,6 +1197,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
       "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -1313,6 +1321,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
       "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -1325,6 +1334,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
       "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -1340,6 +1350,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
       "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3268,6 +3279,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.157.16.tgz",
       "integrity": "sha512-xwFQa7S7dhBhm3aJYwU79cITEYgAKSrcL6wokaROIvl2JyIeazn8jueWqUPJzFjv+QF6Q8euKRlKUEyb5q2ymg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.154.14",
         "@tanstack/react-store": "^0.8.0",
@@ -3437,6 +3449,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.157.16.tgz",
       "integrity": "sha512-eJuVgM7KZYTTr4uPorbUzUflmljMVcaX2g6VvhITLnHmg9SBx9RAgtQ1HmT+72mzyIbRSlQ1q0fY/m+of/fosA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.154.14",
         "@tanstack/store": "^0.8.0",
@@ -3749,6 +3762,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3908,6 +3922,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3917,6 +3932,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4392,6 +4408,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4751,6 +4768,7 @@
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
       "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "srvx": ">=0.7.1"
       },
@@ -4845,7 +4863,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/daisyui": {
       "version": "5.5.14",
@@ -4886,6 +4905,7 @@
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
       "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@electric-sql/pglite": "*",
         "@libsql/client": "*",
@@ -6377,41 +6397,12 @@
         }
       }
     },
-    "node_modules/nitro/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/nitro/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/nitro/node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -6620,7 +6611,8 @@
       "version": "2.0.0-alpha.3",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
       "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -6988,6 +6980,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7108,6 +7101,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7117,6 +7111,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7291,6 +7286,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
       "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7413,6 +7409,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
       "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7487,6 +7484,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -7638,7 +7636,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -7878,6 +7877,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7991,6 +7991,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/hooks/usePinAuth.ts
+++ b/src/hooks/usePinAuth.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type AuthStatus = 'checking' | 'authenticated' | 'unauthenticated';
+
+const STORAGE_KEY = 'rein_session_token';
+
+export function usePinAuth(options: { bypass?: boolean } = {}) {
+    const { bypass = false } = options;
+    const [status, setStatus] = useState<AuthStatus>(bypass ? 'authenticated' : 'checking');
+    const [token, setToken] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        if (bypass) {
+            setStatus('authenticated');
+            return;
+        }
+
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) {
+            setStatus('unauthenticated');
+            return;
+        }
+
+        const verify = async () => {
+            try {
+                const res = await fetch('/api/auth/verify', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ token: stored }),
+                });
+                if (!res.ok) throw new Error('Verification failed');
+                const data = await res.json();
+                if (data?.valid) {
+                    setToken(stored);
+                    setStatus('authenticated');
+                } else {
+                    localStorage.removeItem(STORAGE_KEY);
+                    setStatus('unauthenticated');
+                }
+            } catch {
+                setStatus('unauthenticated');
+            }
+        };
+
+        verify();
+    }, [bypass]);
+
+    const submitPin = useCallback(async (pin: string) => {
+        setIsSubmitting(true);
+        setError(null);
+        try {
+            const res = await fetch('/api/auth/pin', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pin }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data?.error || 'Invalid PIN');
+            }
+            const data = await res.json();
+            if (!data?.token) throw new Error('Invalid response');
+            localStorage.setItem(STORAGE_KEY, data.token);
+            setToken(data.token);
+            setStatus('authenticated');
+            return true;
+        } catch (err: any) {
+            setError(err?.message || 'Invalid PIN');
+            setStatus('unauthenticated');
+            return false;
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, []);
+
+    return { status, token, error, isSubmitting, submitPin };
+}

--- a/src/server/pinAuth.ts
+++ b/src/server/pinAuth.ts
@@ -1,0 +1,26 @@
+import crypto from 'crypto';
+import { IncomingMessage } from 'http';
+
+const PIN_LENGTH = crypto.randomInt(4, 7); // 4 to 6 digits
+const PIN_MAX = 10 ** PIN_LENGTH;
+const PIN = crypto.randomInt(0, PIN_MAX).toString().padStart(PIN_LENGTH, '0');
+
+export function getPin(): string {
+    return PIN;
+}
+
+export function isLocalhost(request: IncomingMessage): boolean {
+    const addr = request.socket.remoteAddress;
+    if (!addr) return false;
+    return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
+export function validatePin(value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed.length !== PIN.length) return false;
+    try {
+        return crypto.timingSafeEqual(Buffer.from(trimmed), Buffer.from(PIN));
+    } catch {
+        return false;
+    }
+}

--- a/src/server/sessionStore.ts
+++ b/src/server/sessionStore.ts
@@ -1,0 +1,49 @@
+import crypto from 'crypto';
+
+interface SessionEntry {
+    token: string;
+    createdAt: number;
+    lastUsed: number;
+    ip?: string;
+}
+
+const EXPIRY_MS = 12 * 60 * 60 * 1000; // 12 hours
+const sessions: SessionEntry[] = [];
+
+function timingSafeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) return false;
+    try {
+        return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+    } catch {
+        return false;
+    }
+}
+
+function purgeExpired(): void {
+    const now = Date.now();
+    for (let i = sessions.length - 1; i >= 0; i -= 1) {
+        if ((now - sessions[i].lastUsed) > EXPIRY_MS) {
+            sessions.splice(i, 1);
+        }
+    }
+}
+
+export function createSession(ip?: string): string {
+    purgeExpired();
+    const now = Date.now();
+    const token = crypto.randomUUID();
+    sessions.push({ token, createdAt: now, lastUsed: now, ip });
+    return token;
+}
+
+export function isValidSession(token: string): boolean {
+    purgeExpired();
+    return sessions.some((entry) => timingSafeEqual(entry.token, token));
+}
+
+export function touchSession(token: string): void {
+    const entry = sessions.find((item) => timingSafeEqual(item.token, token));
+    if (entry) {
+        entry.lastUsed = Date.now();
+    }
+}


### PR DESCRIPTION
Closes #138

## Summary

- Add PIN-based authentication for LAN clients with server-side validation and session tokens.
- Gate WebSocket upgrades to authenticated sessions and terminate unauthorized connections.
- Add lock screen flow on `/trackpad` and display current PIN on `/settings` (localhost only).

---

## Changes

- Added new server authentication modules:
  - PIN generator and validator
  - In-memory session store
- Introduced new API endpoints:
  - `POST /api/auth/pin`
  - `POST /api/auth/verify`
- Updated Trackpad UI to block access until PIN authentication succeeds (remote clients only).
- Updated Settings page:
  - Displays current session PIN
  - Removed token sharing via URL

---

## Testing

- Ran `npm install`  
  - Result: Found 0 vulnerabilities

- Ran `npm test`  
  - Executes `vitest run`  
  - Result: No test files found (exits with code 1)

---

## Notes

- PIN resets automatically on server restart.
- PIN is visible only when accessed from localhost.
- WebSocket now rejects remote connections without a valid session token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented PIN-based authentication system for remote access.
  * Trackpad access now protected behind PIN verification screen (automatic bypass on localhost).
  * Server settings displays current authentication PIN for secure connection.
  * Remote connections require valid PIN-based authentication to establish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->