### PR TITLE
feat: add minimal device pairing with desktop approval

### DIFF
--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -193,6 +193,13 @@ function TrackpadPage() {
 					handlers={handlers}
 					status={status}
 				/>
+				{status === "waiting-approval" && (
+					<div className="absolute inset-0 flex items-center justify-center bg-yellow-200 bg-opacity-75">
+						<p className="text-center text-sm font-semibold">
+							Waiting for desktop approval...
+						</p>
+					</div>
+				)}
 				{bufferText !== "" && <BufferBar bufferText={bufferText} />}
 			</div>
 


### PR DESCRIPTION
## Addressed Issues

Fixes #190 

---

## Description

This PR introduces a **minimal device-pairing workflow with desktop approval** to enhance LAN security without modifying existing functionality.

Previously, any device on the same LAN that knew the server IP and port could connect and begin sending input events. This PR adds a lightweight authorization layer to ensure only approved devices can control the desktop.

The implementation is intentionally minimal and scoped strictly to pairing-related logic.

---

## 🔒 What This PR Adds

### Secure First-Time Pairing Flow

- First-time devices must send a `request-pairing` message.
- Desktop user must explicitly **approve** or **reject** the request.
- Input events from unapproved devices are ignored.
- Approved devices receive a valid token and reconnect normally.
- Localhost behavior remains permissive for development/testing.

---

## 🛠 Implementation Details

### Server Changes (`src/server`)

#### `tokenStore.ts`

- Added `PairingRequest` type.
- Added in-memory pairing request queue.

Implemented:
- `createPairingRequest`
- `getPendingPairingRequests`
- `approvePairingRequest`
- `rejectPairingRequest`

#### `websocket.ts`

- Allows unauthenticated connections to send `request-pairing`.
- Tracks sockets awaiting approval.
- Adds authorization guard: input events are ignored unless token is valid.
- Implements new message handlers:
  - `request-pairing`
  - `get-pending-pairings`
  - `approve-pairing`
  - `reject-pairing`
- Cleans up pending mappings on socket close.

---

### Client Changes

#### `useRemoteConnection.ts`

- Sends `request-pairing` when connecting without a token.
- Handles:
  - `pairing-requested`
  - `pairing-approved`
  - `pairing-rejected`
- Adds new connection status: `waiting-approval`.

#### `settings.tsx`

- Displays pending pairing requests (desktop only).
- Provides **Approve / Reject** buttons.
- Opens localhost WebSocket to fetch and receive pending pairing updates.
- Adds minimal state:
  - `pendingPairings`
  - `wsConnection`

#### `trackpad.tsx`

- Displays banner while awaiting desktop approval.

---

## ✅ Functional Verification

Please check off the behaviors verified with this change.

### Authentication

- [X] Connection doesn't work without a valid token.
- [X] Unapproved devices cannot send input events.
- [X] Approved devices receive a token and reconnect successfully.

### Basic Gestures

- [X] One-finger tap: Verified as Left Click.
- [X] Two-finger tap: Verified as Right Click.
- [X] Click and drag: Verified selection behavior.
- [ ] Pinch to zoom: Verified zoom functionality (if applicable).

### Modes & Settings

- [X] Cursor mode: Cursor moves smoothly and accurately.
- [X] Scroll mode: Page scrolls as expected.
- [X] Sensitivity: Verified changes in cursor speed/sensitivity settings.
- [X] Invert Scrolling: Verified scroll direction toggles correctly.

### Advanced Input

- [X] Key combinations: Verified modifier hold behavior (e.g., Ctrl+C).
- [X] Keyboard input: Verified Space, Backspace, and Enter keys work correctly.
- [ ] Glide typing: Verified path drawing and text output.
- [ ] Voice input: Verified speech-to-text functionality.
- [X] Backspace doesn't send the previous input.

### Any Other Gesture or Input Behavior Introduced

- [X] New Behavior: Devices remain in `waiting-approval` state until approved.

---

## Additional Notes

- Pairing data is kept **in memory only** (no persistence yet).
- Token generation logic remains unchanged.
- QR flow remains unchanged.
- No existing features were modified outside of pairing-related logic.
- Designed to align with current architecture without large refactors.

### Future Enhancements (Not Included in This PR)

- Persistent pairing storage
- Device rename support
- Revocation list UI
- Pairing timeout expiration

---

## Checklist

- [X] My PR addresses a single issue, fixes a single bug, or makes a single improvement.
- [X] My code follows the project's code style and conventions.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] If applicable, I have made corresponding changes or additions to the documentation.
- [ ] If applicable, I have made corresponding changes or additions to tests.
- [X] My changes generate no new warnings or errors.
- [X] I have joined the Discord and I will share a link to this PR with the project maintainers there.
- [X] I have read the contribution guidelines.
- [X] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ ] In case of UI change, I've added a demo video.

---

## ⚠️ AI Notice – Important!

This PR was implemented carefully with attention to maintaining existing behavior. All changes were manually reviewed and verified locally. The feature builds successfully and preserves current functionality outside of the new pairing flow.

Feedback and architectural suggestions are welcome. 🚀