### PR TITLE
fix: implement non-functional copy/paste buttons in ControlBar

### DIFF
--- a/src/components/Trackpad/ControlBar.tsx
+++ b/src/components/Trackpad/ControlBar.tsx
@@ -18,6 +18,8 @@ interface ControlBarProps {
 	onRightClick: () => void
 	onKeyboardToggle: () => void
 	onModifierToggle: () => void
+	onCopy: () => void
+	onPaste: () => void
 	keyboardOpen: boolean
 	extraKeysVisible: boolean
 	onExtraKeysToggle: () => void
@@ -31,6 +33,8 @@ export const ControlBar: React.FC<ControlBarProps> = ({
 	onRightClick,
 	onKeyboardToggle,
 	onModifierToggle,
+	onCopy,
+	onPaste,
 	buffer,
 }) => {
 	const handleInteraction = (e: React.PointerEvent, action: () => void) => {
@@ -101,11 +105,19 @@ export const ControlBar: React.FC<ControlBarProps> = ({
 				<Mouse size={18} className="rotate-180" />
 			</button>
 
-			<button type="button" className={baseButton}>
+			<button
+				type="button"
+				className={baseButton}
+				onPointerDown={(e) => handleInteraction(e, onCopy)}
+			>
 				<Copy size={18} />
 			</button>
 
-			<button type="button" className={baseButton}>
+			<button
+				type="button"
+				className={baseButton}
+				onPointerDown={(e) => handleInteraction(e, onPaste)}
+			>
 				<ClipboardPaste size={18} />
 			</button>
 

--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -66,6 +66,14 @@ function TrackpadPage() {
 		setTimeout(() => send({ type: "click", button, press: false }), 50)
 	}
 
+	const handleCopy = () => {
+		sendCombo(["ctrl", "c"])
+	}
+
+	const handlePaste = () => {
+		sendCombo(["ctrl", "v"])
+	}
+
 	const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const nativeEvent = e.nativeEvent as InputEvent
 		const inputType = nativeEvent.inputType
@@ -198,7 +206,7 @@ function TrackpadPage() {
 
 			{/* CONTROL BAR */}
 			<div className="shrink-0 border-b border-base-200">
-				<ControlBar
+			<ControlBar
 					scrollMode={scrollMode}
 					modifier={modifier}
 					buffer={buffer.join(" + ")}
@@ -209,6 +217,8 @@ function TrackpadPage() {
 					onRightClick={() => handleClick("right")}
 					onKeyboardToggle={toggleKeyboard}
 					onModifierToggle={handleModifierState}
+					onCopy={handleCopy}
+					onPaste={handlePaste}
 					onExtraKeysToggle={() => setExtraKeysVisible((prev) => !prev)}
 				/>
 			</div>


### PR DESCRIPTION
fix #192 

Fixed non-functional Copy/Paste buttons in ControlBar - now sends Ctrl+C/Ctrl+V combos via WebSocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy and paste functionality is now available through the trackpad control bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->