### PR TITLE
Fix: Improve LAN IP detection to avoid selecting Docker/VPN interfaces (Fixes #27)

### DIFF
--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -46,6 +46,9 @@ function getLocalIp(): string {
     "tun",
     "tap",
     "tailscale",
+	"utun",
+	"awdl",
+	"llw",
   ];
 
   const ignoredPrefixes = [


### PR DESCRIPTION
Addressed Issues:
Fixes #27 

Description

The current getLocalIp() implementation returns the first non-internal IPv4 address from os.networkInterfaces(). On machines with Docker, VPN, or VM adapters installed, this often results in selecting a virtual interface IP (e.g., 172.17.x.x) instead of the actual LAN IP (e.g., 192.168.x.x), causing the QR-generated address to be unreachable from mobile devices.

This PR refines the auto-detection logic to better align with the expected behavior described in the issue:

Filters out common virtual/tunnel interfaces (e.g., docker, veth, tun, tap, vmnet, etc.).
Restricts selection to RFC1918 private IPv4 ranges (192.168.x.x, 10.x.x.x, 172.16–31.x.x).
Handles Node versions where net.family may be numeric (4) instead of "IPv4".
Preserves the existing function signature and "localhost" fallback behavior.
Does not introduce architectural changes, new exports, or UI modifications.
This implements the "filter for most likely LAN interface" approach mentioned in the issue, while keeping the change minimal and safe.

Modes & Settings
 Settings page still loads correctly.
 Server IP auto-detection still works.
 QR generation unaffected (uses updated LAN IP logic).

Advanced Input
 No changes to input handling logic.
Any other gesture or input behavior introduced:
 one (this PR only modifies LAN IP detection logic).

Additional Notes:

This PR intentionally avoids implementing the alternative dropdown-based selection approach mentioned in the issue to keep the scope limited to correcting the backend IP auto-detection logic. The dropdown enhancement can be implemented as a separate feature PR if required.

Checklist

 My PR addresses a single issue, fixes a single bug or makes a single improvement.
 My code follows the project's code style and conventions.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 If applicable, I have made corresponding changes or additions to the documentation.
 If applicable, I have made corresponding changes or additions to tests.
 My changes generate no new warnings or errors.
 I have read the contribution guidelines.

 Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local network IP address detection by filtering out virtual and tunnel network interfaces, prioritizing private IPv4 addresses for more reliable LAN connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->