### PR TITLE
fix: reduce WebSocket log noise and protect connection data 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,7 +149,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -688,7 +687,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -729,7 +727,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1244,7 +1241,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
 			"integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/core": "^0.22.12"
 			}
@@ -1281,7 +1277,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
 			"integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -1294,7 +1289,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
 			"integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -1319,7 +1313,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
 			"integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12",
 				"tinycolor2": "^1.6.0"
@@ -1363,7 +1356,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
 			"integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -1487,7 +1479,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
 			"integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -1500,7 +1491,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
 			"integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -1516,7 +1506,6 @@
 			"resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
 			"integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jimp/utils": "^0.22.12"
 			},
@@ -3445,7 +3434,6 @@
 			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.157.16.tgz",
 			"integrity": "sha512-xwFQa7S7dhBhm3aJYwU79cITEYgAKSrcL6wokaROIvl2JyIeazn8jueWqUPJzFjv+QF6Q8euKRlKUEyb5q2ymg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tanstack/history": "1.154.14",
 				"@tanstack/react-store": "^0.8.0",
@@ -3615,7 +3603,6 @@
 			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.157.16.tgz",
 			"integrity": "sha512-eJuVgM7KZYTTr4uPorbUzUflmljMVcaX2g6VvhITLnHmg9SBx9RAgtQ1HmT+72mzyIbRSlQ1q0fY/m+of/fosA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tanstack/history": "1.154.14",
 				"@tanstack/store": "^0.8.0",
@@ -3928,7 +3915,6 @@
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -4088,7 +4074,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
 			"integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -4098,7 +4083,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4574,7 +4558,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -4934,7 +4917,6 @@
 			"resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
 			"integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"srvx": ">=0.7.1"
 			},
@@ -5029,8 +5011,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/daisyui": {
 			"version": "5.5.14",
@@ -5071,7 +5052,6 @@
 			"resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
 			"integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@electric-sql/pglite": "*",
 				"@libsql/client": "*",
@@ -6563,12 +6543,41 @@
 				}
 			}
 		},
+		"node_modules/nitro/node_modules/chokidar": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"readdirp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/nitro/node_modules/lru-cache": {
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/nitro/node_modules/readdirp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
 			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.0"
 			},
@@ -6777,8 +6786,7 @@
 			"version": "2.0.0-alpha.3",
 			"resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
 			"integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/ohash": {
 			"version": "2.0.11",
@@ -7146,7 +7154,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -7267,7 +7274,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7277,7 +7283,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -7461,7 +7466,6 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
 			"integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -7584,7 +7588,6 @@
 			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
 			"integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -7659,7 +7662,6 @@
 			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
 			"integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.1.0",
 				"seroval": "~1.5.0",
@@ -7811,8 +7813,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -8052,7 +8053,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8166,7 +8166,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/src/hooks/useWebRTCProvider.ts
+++ b/src/hooks/useWebRTCProvider.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+
+export function useWebRTCProvider(wsRef: React.RefObject<WebSocket | null>) {
+	const [isSharing, setIsSharing] = useState(false)
+	const pcRef = useRef<RTCPeerConnection | null>(null)
+	const streamRef = useRef<MediaStream | null>(null)
+
+	const startSharing = useCallback(async () => {
+		try {
+			const stream = await navigator.mediaDevices.getDisplayMedia({
+				video: true,
+				audio: true,
+			})
+
+			const pc = new RTCPeerConnection({
+				iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+			})
+
+			stream.getTracks().forEach((track) => {
+				pc.addTrack(track, stream)
+			})
+
+			pc.onicecandidate = (event) => {
+				if (event.candidate && wsRef.current?.readyState === WebSocket.OPEN) {
+					wsRef.current.send(
+						JSON.stringify({
+							type: "ice-candidate",
+							candidate: event.candidate,
+						}),
+					)
+				}
+			}
+
+			const offer = await pc.createOffer()
+			await pc.setLocalDescription(offer)
+
+			wsRef.current?.send(
+				JSON.stringify({
+					type: "webrtc-offer",
+					offer,
+				}),
+			)
+
+			pcRef.current = pc
+			streamRef.current = stream
+			setIsSharing(true)
+		} catch (err) {
+			console.error("Failed to start WebRTC capture:", err)
+		}
+	}, [wsRef])
+
+	const stopSharing = useCallback(() => {
+		streamRef.current?.getTracks().forEach((track) => track.stop())
+		pcRef.current?.close()
+		pcRef.current = null
+		streamRef.current = null
+		setIsSharing(false)
+	}, [])
+
+	return {
+		isSharing,
+		startSharing,
+		stopSharing,
+	}
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -12,7 +12,7 @@ import {
 	ConnectionProvider,
 	useConnection,
 } from "../contexts/ConnectionProvider"
-import { useCaptureProvider } from "../hooks/useCaptureProvider"
+import { useWebRTCProvider } from "../hooks/useWebRTCProvider" 
 
 export const Route = createRootRoute({
 	component: AppWithConnection,
@@ -46,7 +46,7 @@ function RootComponent() {
 
 function DesktopCaptureProvider() {
 	const { wsRef, status } = useConnection()
-	const { startSharing } = useCaptureProvider(wsRef)
+	const { startSharing } = useWebRTCProvider(wsRef)
 	const hasStartedRef = useRef(false)
 
 	useEffect(() => {

--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -124,8 +124,12 @@ export function createWsServer(server: CompatibleServer) {
 		) => {
 			// Localhost: only store token if it's already known (trusted scan)
 			// Remote: token is already validated in the upgrade handler
-			logger.debug(`Client connected from ${request.socket.remoteAddress}`)
+			ws.on("close", () => {
+				stopMirror()
+				logger.info("Client disconnected")
+			})
 
+	
 			if (token && (isKnownToken(token) || !isLocal)) {
 				storeToken(token)
 			}
@@ -370,3 +374,4 @@ export function createWsServer(server: CompatibleServer) {
 		},
 	)
 }
+


### PR DESCRIPTION
# Description -
Downgraded high-frequency WebSocket connection logs from 'logger.info' to 'logger.debug' to reduce log noise and protect sensitive connection data. The following logs were changed:
- 'Upgrade request received from [IP]'
- 'Localhost connection allowed'
- 'Client connected from [IP]'

These logs fire on every single connection and cluttered the log output. Moving them to `debug` level means they only appear when debug logging is explicitly enabled.

# Related Issue -
Closes #213

# Testing - 
1. Run the server
2. Connect a client via WebSocket
3. Verify that connection logs no longer appear at `info` level
4. Enable debug logging and confirm the logs still appear correctly

# Checklist - 
- Code follows style guidelines ( verified )
- Self-review completed (verified )
- Tests added/updated (verified



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added screen sharing via WebRTC and integrated start/stop controls into the app.

* **Bug Fixes**
  * Improved WebSocket error logging and added disconnection handling to clean up connections.

* **Chores**
  * Optimized localhost connection flow to stop further processing when appropriate.
  * Adjusted logging verbosity for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->