### PR TITLE
fix(screen-mirror): grant display-capture permission in Electron executables

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, systemPreferences } = require('electron');
 const path = require('path');
 const { spawn } = require('child_process');
 const http = require('http');
@@ -60,13 +60,44 @@ function createWindow() {
     width: 1200,
     height: 800,
     show: false,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
   });
+
+  // Grant screen-capture permission requests only from the trusted local
+  // origin and only for display-capture / screen. Without this handler
+  // Electron silently denies getDisplayMedia in packaged builds.
+  const TRUSTED_ORIGIN = 'http://localhost:3000';
+  mainWindow.webContents.session.setPermissionRequestHandler(
+    (webContents, permission, callback) => {
+      const origin = webContents.getURL();
+      const isScreenCapture = permission === 'display-capture' || permission === 'screen';
+      callback(origin.startsWith(TRUSTED_ORIGIN) && isScreenCapture);
+    }
+  );
+
+  // Allow permission checks (e.g. navigator.permissions.query) for the same
+  // trusted origin and screen-capture permissions only.
+  mainWindow.webContents.session.setPermissionCheckHandler(
+    (webContents, permission) => {
+      const origin = webContents ? webContents.getURL() : '';
+      const isScreenCapture = permission === 'display-capture' || permission === 'screen';
+      return origin.startsWith(TRUSTED_ORIGIN) && isScreenCapture;
+    }
+  );
 
   mainWindow.loadURL('http://localhost:3000');
 
   // Show when ready
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
+  });
+
+  // Clear the reference so createWindow() can recreate it (macOS dock reopen)
+  mainWindow.on('closed', () => {
+    mainWindow = null;
   });
 
   // Debug only if needed
@@ -77,12 +108,42 @@ function createWindow() {
 
 // App start
 app.whenReady().then(async () => {
+  // On macOS, screen-recording permission cannot be requested programmatically
+  // via the Electron API (askForMediaAccess does not support 'screen').
+  // If the permission has not been granted yet, show a dialog directing the
+  // user to enable it in System Preferences → Privacy & Security → Screen Recording.
+  if (process.platform === 'darwin') {
+    const status = systemPreferences.getMediaAccessStatus('screen');
+    if (status !== 'granted') {
+      const { dialog } = require('electron');
+      dialog.showMessageBoxSync({
+        type: 'warning',
+        title: 'Screen Recording Permission Required',
+        message: 'Rein needs Screen Recording permission to mirror your display.',
+        detail:
+          'Please open System Preferences → Privacy & Security → Screen Recording ' +
+          'and enable Rein, then restart the app.',
+        buttons: ['OK'],
+      });
+    }
+  }
+
   await startServer();
   createWindow();
 });
 
 // Cleanup
 app.on('window-all-closed', () => {
-  if (serverProcess) serverProcess.kill();
-  if (process.platform !== 'darwin') app.quit();
+  // On macOS the server keeps running so the app can be reopened via the
+  // dock without restarting the Nitro process. Only kill the server and
+  // quit on platforms where closing all windows means the app is done.
+  if (process.platform !== 'darwin') {
+    if (serverProcess) serverProcess.kill();
+    app.quit();
+  }
+});
+
+// macOS: re-create window when dock icon is clicked
+app.on('activate', () => {
+  if (!mainWindow) createWindow();
 });


### PR DESCRIPTION
## What & Why

`getDisplayMedia` (screen mirroring) was silently denied in packaged Electron builds because Electron does not inherit browser permission grants — it needs explicit `setPermissionRequestHandler` / `setPermissionCheckHandler` hooks.

Closes #254

## Changes

**electron/main.cjs only:**

| Change | Reason |
|---|---|
| Add `setPermissionRequestHandler` | Allows `display-capture` / `screen` requests from `http://localhost:3000` only |
| Add `setPermissionCheckHandler` | Allows `navigator.permissions.query` checks for the same permissions |
| Add `contextIsolation: true`, `nodeIntegration: false` | Security best-practice webPreferences |
| Add macOS startup dialog | Screen recording cannot be requested programmatically on macOS; guide user to System Preferences |
| Null `mainWindow` on `closed` | Fixes guard in `createWindow()` so macOS dock reopen works |
| Add `activate` handler | Re-creates window when dock icon is clicked (macOS convention) |
| Fix `window-all-closed` | Don't kill server on macOS; let dock reopen work without restarting Nitro |

## Testing

- Run packaged build (`npm run dist`) on Windows or Linux
- Open the screen mirroring page — `getDisplayMedia` should now prompt successfully instead of silently failing
- On macOS without screen recording permission: a dialog should appear at startup

> Screenshot / screen recording will be added shortly.