### PR TITLE
fix(websocket): bind server to 0.0.0.0 so LAN clients can connect

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -43,7 +43,7 @@ function startServer() {
       windowsHide: true,     // hide CMD
       env: {
         ...process.env,
-        HOST: '127.0.0.1',
+        HOST: '0.0.0.0',
         PORT: '3000',
       },
     });


### PR DESCRIPTION
## Summary

Fixes #259

The Nitro/HTTP server spawned in `electron/main.cjs` had `HOST` hardcoded to `'127.0.0.1'`. The WebSocket server piggybacks on that same server via `{ noServer: true }`, so it inherited the loopback-only binding. Any mobile or desktop client on the LAN trying to connect was refused with `ECONNREFUSED`.

### Root cause

```js
// electron/main.cjs ~line 46 (before)
HOST: '127.0.0.1',
```

### Fix

```js
// electron/main.cjs (after)
HOST: '0.0.0.0',
```

Binding to `0.0.0.0` makes the server listen on all network interfaces, so remote devices on the same LAN can reach both the HTTP server and the WebSocket upgrade endpoint.

`waitForServer` still polls `http://localhost:3000`, which continues to work correctly when the server binds to `0.0.0.0`.

## Files changed

- `electron/main.cjs` — 1 line changed (`HOST` value)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server network configuration to listen on all available network interfaces, enhancing connectivity access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->