### PR TITLE
[Doc] Add instructions for running Rein on Virtual Machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,23 @@ Run the following commands inside the virtual machine:
 npm install
 npm run dev
 ```
+
 ### Find the VM IP Address
 
-Linux / macOS:
-
+Linux:
 ```bash
 ip a
+```
+macOS:
+```bash
+ifconfig
 ```
 Windows:
 
 ```bash
 ipconfig
 ```
+
 ### Connect From Your Phone
 
 Open this address on your phone browser:


### PR DESCRIPTION
### Addressed Issue

Related to #107

### Description

This PR adds documentation explaining how to run and test **Rein inside Virtual Machines** such as VirtualBox or VMware.

### Changes

* Added a new section **"Running Rein in a Virtual Machine"** in the README
* Instructions for configuring **Bridged Networking**
* Steps to start the development server inside the VM
* Instructions to find the **VM IP address**
* Guidance on connecting from a mobile device

### Notes

This helps developers test Rein in an isolated environment without needing a separate physical device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for running Rein inside a Virtual Machine: bridged networking setup, VM startup and app launch commands, methods to find the VM IP on Linux/macOS/Windows, instructions to access the app from a phone (http://<VM_IP>:3000), and firewall guidance for exposing port 3000. Also includes a multi-step usage flow and contribution note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->