### PR TITLE
poc(webrtc): WebRTC screen mirror — replace canvas/JPEG pipeline (Issue #208)

### DIFF
--- a/src/hooks/useWebRTCCapture.ts
+++ b/src/hooks/useWebRTCCapture.ts
@@ -1,0 +1,123 @@
+/**
+ * useWebRTCCapture.ts
+ *
+ * Proof-of-concept WebRTC screen capture hook for Issue #208.
+ * Replaces useCaptureProvider.ts entirely.
+ *
+ * Key differences vs the canvas/JPEG approach:
+ * - No FPS cap: H.264/VP8/VP9 hardware encoder runs at full display refresh rate
+ * - Wayland works: getDisplayMedia() in Electron triggers xdg-desktop-portal
+ *   (pipewire) automatically — no WAYLAND_DISPLAY config needed
+ * - No canvas, no toBlob(), no WebSocket binary frames — WebRTC handles encoding
+ * - ICE signalling reuses the existing HTTP server via /api/webrtc-signal
+ *
+ * Usage (host side — the machine being controlled):
+ *   const { startCapture, stopCapture, isCapturing } = useWebRTCCapture()
+ *   await startCapture(sessionId)   // opens getDisplayMedia picker
+ *
+ * The viewer (mobile browser) connects to /api/webrtc-signal with the same
+ * sessionId, receives the SDP answer, and renders the stream in a <video>.
+ *
+ * Full GSoC implementation will:
+ * - Delete useCaptureProvider.ts
+ * - Delete useMirrorStream.ts (canvas consumer)
+ * - Replace with this hook + useWebRTCViewer.ts on the client side
+ */
+
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+
+interface SignalMessage {
+	type: "offer" | "answer" | "ice-candidate" | "bye"
+	sessionId: string
+	payload: RTCSessionDescriptionInit | RTCIceCandidateInit | null
+}
+
+async function signal(msg: SignalMessage): Promise<SignalMessage | null> {
+	const res = await fetch("/api/webrtc-signal", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(msg),
+	})
+	if (!res.ok) return null
+	return res.json() as Promise<SignalMessage>
+}
+
+export function useWebRTCCapture() {
+	const [isCapturing, setIsCapturing] = useState(false)
+	const pcRef = useRef<RTCPeerConnection | null>(null)
+	const streamRef = useRef<MediaStream | null>(null)
+
+	const stopCapture = useCallback(() => {
+		if (streamRef.current) {
+			for (const track of streamRef.current.getTracks()) track.stop()
+			streamRef.current = null
+		}
+		if (pcRef.current) {
+			pcRef.current.close()
+			pcRef.current = null
+		}
+		setIsCapturing(false)
+	}, [])
+
+	const startCapture = useCallback(
+		async (sessionId: string) => {
+			try {
+				// getDisplayMedia: triggers Wayland pipewire portal automatically in Electron
+				const stream = await navigator.mediaDevices.getDisplayMedia({
+					video: { frameRate: { ideal: 60, max: 60 } },
+					audio: false,
+				})
+
+				streamRef.current = stream
+
+				// LAN-only — no STUN/TURN needed, ICE will resolve local addresses directly
+				const pc = new RTCPeerConnection({ iceServers: [] })
+				pcRef.current = pc
+
+				// Add all video tracks to the peer connection
+				for (const track of stream.getTracks()) {
+					pc.addTrack(track, stream)
+				}
+
+				// Trickle ICE: send candidates to signalling server as they arrive
+				pc.onicecandidate = ({ candidate }) => {
+					if (candidate) {
+						signal({
+							type: "ice-candidate",
+							sessionId,
+							payload: candidate.toJSON(),
+						}).catch(console.error)
+					}
+				}
+
+				// Create SDP offer and send to signalling server
+				const offer = await pc.createOffer()
+				await pc.setLocalDescription(offer)
+
+				const response = await signal({
+					type: "offer",
+					sessionId,
+					payload: offer,
+				})
+
+				if (response?.payload) {
+					await pc.setRemoteDescription(
+						response.payload as RTCSessionDescriptionInit,
+					)
+					setIsCapturing(true)
+				}
+
+				// Handle stream ending (user clicks "Stop sharing" in OS dialog)
+				stream.getVideoTracks()[0].onended = () => stopCapture()
+			} catch (err) {
+				console.error("useWebRTCCapture: failed to start", err)
+				stopCapture()
+			}
+		},
+		[stopCapture],
+	)
+
+	return { isCapturing, startCapture, stopCapture }
+}

--- a/src/routes/api/webrtc-signal.ts
+++ b/src/routes/api/webrtc-signal.ts
@@ -1,0 +1,142 @@
+/**
+ * webrtc-signal.ts
+ *
+ * WebRTC signalling endpoint for Issue #208.
+ * Handles SDP offer/answer exchange and ICE candidate trickle for LAN WebRTC.
+ *
+ * This is a TanStack Start API route — it reuses the existing HTTP server
+ * with no extra port or external signalling service required.
+ *
+ * Protocol:
+ *   POST /api/webrtc-signal   { type: "offer", sessionId, payload: SDP }
+ *     → stores offer, waits for viewer answer, returns { answer: SDP }
+ *
+ *   POST /api/webrtc-signal   { type: "answer", sessionId, payload: SDP }
+ *     → stores answer for the waiting offer handler
+ *
+ *   POST /api/webrtc-signal   { type: "ice-candidate", sessionId, payload: ICE }
+ *     → stores candidate; viewer polls or long-polls to pick up
+ *
+ *   POST /api/webrtc-signal   { type: "bye", sessionId, payload: null }
+ *     → cleans up session state
+ *
+ * Full GSoC implementation will add:
+ * - Long-poll or Server-Sent Events for ICE candidate delivery to viewer
+ * - Session timeout / garbage collection
+ * - Auth token validation before accepting offers
+ */
+
+import { createAPIFileRoute } from "@tanstack/start/api"
+
+interface SessionState {
+	offer?: RTCSessionDescriptionInit
+	answer?: RTCSessionDescriptionInit
+	iceCandidates: RTCIceCandidateInit[]
+	answerResolvers: Array<(answer: RTCSessionDescriptionInit) => void>
+	createdAt: number
+}
+
+// In-memory store — sufficient for single-user LAN use case
+const sessions = new Map<string, SessionState>()
+
+const SESSION_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+function getOrCreateSession(id: string): SessionState {
+	let s = sessions.get(id)
+	if (!s) {
+		s = { iceCandidates: [], answerResolvers: [], createdAt: Date.now() }
+		sessions.set(id, s)
+		// Auto-cleanup after timeout
+		setTimeout(() => sessions.delete(id), SESSION_TIMEOUT_MS)
+	}
+	return s
+}
+
+function waitForAnswer(
+	session: SessionState,
+	timeoutMs = 10_000,
+): Promise<RTCSessionDescriptionInit> {
+	return new Promise((resolve, reject) => {
+		if (session.answer) return resolve(session.answer)
+		const timer = setTimeout(
+			() => reject(new Error("Timeout waiting for WebRTC answer")),
+			timeoutMs,
+		)
+		session.answerResolvers.push((answer) => {
+			clearTimeout(timer)
+			resolve(answer)
+		})
+	})
+}
+
+export const APIRoute = createAPIFileRoute("/api/webrtc-signal")({
+	POST: async ({ request }) => {
+		const { type, sessionId, payload } = (await request.json()) as {
+			type: "offer" | "answer" | "ice-candidate" | "bye"
+			sessionId: string
+			payload: RTCSessionDescriptionInit | RTCIceCandidateInit | null
+		}
+
+		if (!sessionId || typeof sessionId !== "string") {
+			return Response.json({ error: "sessionId required" }, { status: 400 })
+		}
+
+		const session = getOrCreateSession(sessionId)
+
+		switch (type) {
+			case "offer": {
+				session.offer = payload as RTCSessionDescriptionInit
+				try {
+					const answer = await waitForAnswer(session)
+					return Response.json({ type: "answer", payload: answer })
+				} catch {
+					return Response.json(
+						{ error: "No answer received in time" },
+						{ status: 504 },
+					)
+				}
+			}
+
+			case "answer": {
+				session.answer = payload as RTCSessionDescriptionInit
+				// Wake up any waiting offer handlers
+				for (const resolve of session.answerResolvers) {
+					resolve(session.answer)
+				}
+				session.answerResolvers = []
+				return Response.json({ ok: true })
+			}
+
+			case "ice-candidate": {
+				if (payload) {
+					session.iceCandidates.push(payload as RTCIceCandidateInit)
+				}
+				return Response.json({ ok: true })
+			}
+
+			case "bye": {
+				sessions.delete(sessionId)
+				return Response.json({ ok: true })
+			}
+
+			default:
+				return Response.json({ error: "Unknown signal type" }, { status: 400 })
+		}
+	},
+
+	// Viewer polls for ICE candidates
+	GET: async ({ request }) => {
+		const url = new URL(request.url)
+		const sessionId = url.searchParams.get("sessionId")
+		if (!sessionId)
+			return Response.json({ error: "sessionId required" }, { status: 400 })
+
+		const session = sessions.get(sessionId)
+		if (!session) return Response.json({ candidates: [], offer: null })
+
+		return Response.json({
+			offer: session.offer ?? null,
+			candidates: session.iceCandidates,
+		})
+	},
+})


### PR DESCRIPTION
Closes #208

## What this is

Reference implementation / PoC for Issue #208, submitted as a proposal artifact. Will be closed after review — the full integration (deleting `useCaptureProvider.ts` and `useMirrorStream.ts`) happens during GSoC.

---

## The problem with the current canvas/JPEG pipeline

`useCaptureProvider.ts` captures frames with `canvas.toBlob()` → sends as WebSocket binary → renders on `<canvas>`. Three structural problems:

1. **FPS cap** — frame rate is bounded by WebSocket round-trip + JPEG/WebP encoding time. Even on fast LAN, smooth 30+ FPS is unreliable
2. **Wayland broken** — `getDisplayMedia()` on Wayland requires the `pipewire` portal. The canvas approach doesn't use it automatically, so screen mirroring silently fails on Wayland GNOME/KDE without manual `WAYLAND_DISPLAY` config
3. **No hardware acceleration** — `canvas.toBlob()` is CPU-only. On low-power machines this causes visible encode lag

---

## Approach: WebRTC `getDisplayMedia()` → `RTCPeerConnection`

```
Host (Electron / browser)                 Viewer (mobile browser)
─────────────────────────                 ───────────────────────
getDisplayMedia()                         GET /api/webrtc-signal?sessionId=...
  → MediaStream                             → receives SDP offer
  → RTCPeerConnection                     RTCPeerConnection.setRemoteDescription(offer)
  → createOffer()                         createAnswer()
  → POST /api/webrtc-signal (offer)  ←→  POST /api/webrtc-signal (answer)
  → setRemoteDescription(answer)          setLocalDescription(answer)
  → trickle ICE candidates           ←→  trickle ICE candidates
                                          stream.srcObject = pc.stream
                                          <video> renders at 60 FPS
```

**No canvas. No JPEG. No WebSocket binary frames.** The browser's hardware H.264/VP8 encoder handles everything.

---

## Files added

| File | Purpose |
|---|---|
| `src/hooks/useWebRTCCapture.ts` | Host-side hook — replaces `useCaptureProvider.ts` |
| `src/routes/api/webrtc-signal.ts` | TanStack Start API route — SDP offer/answer + ICE trickle |

---

## Why this works on Wayland

`getDisplayMedia()` in Electron calls into the browser's platform-specific capture backend. On Linux, Chromium's implementation automatically uses `xdg-desktop-portal` → `pipewire` when Wayland is detected. No `WAYLAND_DISPLAY` env var or manual configuration needed.

---

## Why no STUN/TURN is needed

```typescript
const pc = new RTCPeerConnection({ iceServers: [] }) // empty — LAN only
```

ICE will find the local LAN address directly. STUN/TURN are only needed when NAT traversal is required (public internet). On a LAN, both peers are on the same subnet and can connect directly.

---

## Signalling design

The signalling server is a TanStack Start API route at `/api/webrtc-signal`. It reuses the existing HTTP server — no extra port, no WebSocket for signalling, no external service.

- `POST { type: "offer" }` → server holds request open until viewer answers (long-poll pattern, 10s timeout)
- `POST { type: "answer" }` → resolves the waiting offer request
- `POST { type: "ice-candidate" }` → stored in-memory, viewer polls via `GET`
- `POST { type: "bye" }` → cleans up session

Single-user LAN use case: at most one active session at a time. No database needed.

---

## What the full GSoC implementation will change

- Delete `src/hooks/useCaptureProvider.ts` (canvas/JPEG hook)
- Delete `src/hooks/useMirrorStream.ts` (canvas consumer)
- Replace `<canvas>` in the screen mirror route with `<video srcObject={...}>`
- Add `useWebRTCViewer.ts` hook for the viewer side (mobile browser)
- Add Electron `webContents.setDisplayMediaRequestHandler` for packaged builds
- Integration tests: Wayland GNOME, X11, Windows Electron, mobile Chrome