### PR TITLE
fix(packaging): persist config to userData, permission handlers, release CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release Electron
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Clean node_modules and npm cache (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          if (Test-Path node_modules) { Remove-Item -Recurse -Force node_modules }
+          npm cache clean --force
+        shell: pwsh
+
+      - name: Clean node_modules and npm cache (macOS/Linux)
+        if: runner.os != 'Windows'
+        run: |
+          rm -rf node_modules package-lock.json || true
+          npm cache clean --force
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: npm ci --include=optional
+
+      - name: Install dependencies (macOS/Linux)
+        if: runner.os != 'Windows'
+        run: npm install --include=optional --force
+
+      - name: Rebuild native dependencies
+        run: npx electron-builder install-app-deps
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Package and publish Electron app (Windows)
+        if: runner.os == 'Windows'
+        run: npm run dist -- --win --publish=always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and publish Electron app (Linux)
+        if: runner.os == 'Linux'
+        run: npm run dist -- --linux --publish=always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and publish Electron app (macOS)
+        if: runner.os == 'macOS'
+        run: npm run dist -- --mac --publish=always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.os }}
+          path: dist/**
+          retention-days: 30

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, session } = require('electron');
 const path = require('path');
 const { spawn } = require('child_process');
 const http = require('http');
@@ -6,13 +6,29 @@ const fs = require('fs');
 
 let mainWindow;
 let serverProcess;
-let serverHost = '0.0.0.0';
+let serverHost = '0.0.0.0';  // Bind to all interfaces so LAN clients can connect
 let serverPort = 3000;
 
+// ── User-data directory (survives reinstall and version upgrades) ─────────────
+// Fix for Issue #115: previously config was stored relative to the executable
+// and wiped on every reinstall. app.getPath('userData') persists correctly on:
+//   Linux:   ~/.config/rein
+//   macOS:   ~/Library/Application Support/rein
+//   Windows: %APPDATA%\rein
+const USER_DATA_DIR = app.getPath('userData');
+const CONFIG_FILE   = path.join(USER_DATA_DIR, 'server-settings.json');
+const TOKENS_FILE   = path.join(USER_DATA_DIR, 'tokens.json');
+
+// Ensure user data directory exists
+try { fs.mkdirSync(USER_DATA_DIR, { recursive: true }); } catch {}
+
+// Expose paths to the server process via environment variables
+process.env.REIN_CONFIG_FILE = CONFIG_FILE;
+process.env.REIN_TOKENS_FILE = TOKENS_FILE;
+
 try {
-  const configPath = './src/server-config.json';
-  if (fs.existsSync(configPath)) {
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  if (fs.existsSync(CONFIG_FILE)) {
+    const config = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'));
     if (config.host) serverHost = config.host;
     if (config.frontendPort) serverPort = config.frontendPort;
   }
@@ -74,6 +90,25 @@ function createWindow() {
     width: 1200,
     height: 800,
     show: false,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  // Grant display-capture and screen permissions for screen mirroring
+  // (Electron does not inherit browser permission grants automatically)
+  session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    const allowedPermissions = ['display-capture', 'screen', 'media'];
+    const isLocalhost = webContents.getURL().startsWith(`http://localhost:${serverPort}`);
+    callback(isLocalhost && allowedPermissions.includes(permission));
+  });
+
+  session.defaultSession.setPermissionCheckHandler((webContents, permission) => {
+    const allowedPermissions = ['display-capture', 'screen', 'media'];
+    const isLocalhost = webContents.getURL().startsWith(`http://localhost:${serverPort}`);
+    return isLocalhost && allowedPermissions.includes(permission);
   });
 
   mainWindow.loadURL(`http://localhost:${serverPort}`);
@@ -83,9 +118,12 @@ function createWindow() {
     mainWindow.show();
   });
 
-  // Debug only if needed
   mainWindow.webContents.on('did-fail-load', (e, code, desc) => {
     console.log("LOAD FAILED:", code, desc);
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
   });
 }
 
@@ -93,10 +131,16 @@ function createWindow() {
 app.whenReady().then(async () => {
   await startServer();
   createWindow();
+
+  // macOS: re-create window when dock icon is clicked
+  app.on('activate', () => {
+    if (!mainWindow) createWindow();
+  });
 });
 
 // Cleanup
 app.on('window-all-closed', () => {
   if (serverProcess) serverProcess.kill();
+  // On macOS, keep the process alive until user quits explicitly (Cmd+Q)
   if (process.platform !== 'darwin') app.quit();
 });


### PR DESCRIPTION
## Summary

Closes #115

This PR is a **GSoC 2026 proposal reference artifact** demonstrating concrete design and implementation work for the _Packaging Pipelines_ issue. The full implementation will happen during the GSoC coding period.

---

## Problem

Rein currently has no automated release pipeline. Builds are manual, config files are written next to the executable (breaking on Linux/macOS AppImage), and there are no permission handlers for `display-capture`/`screen` in the Electron security layer.

---

## Changes in this PR

### 1. `electron/main.cjs` — Electron main process fixes

| Fix | Details |
|-----|---------|
| Persistent config dir | `app.getPath('userData')` replaces relative paths — survives AppImage/ASAR extraction |
| Env vars to server | `REIN_CONFIG_FILE` + `REIN_TOKENS_FILE` passed to child process |
| Permission handlers | `setPermissionRequestHandler` + `setPermissionCheckHandler` for `display-capture`, `screen`, `media` |
| Security hardening | `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true` |
| macOS lifecycle | `activate` handler restores window from dock; `window-all-closed` fixed for macOS |
| Memory safety | `mainWindow = null` on `closed` to release BrowserWindow reference |

### 2. `.github/workflows/release.yml` — Automated release pipeline (new file)

```
Trigger: git tag push  (v*.*.*)
Matrix:  windows-latest | ubuntu-latest | macos-latest
Steps:
  checkout → setup-node@v4 (node 20) → clean cache
  → npm install → electron-builder install-app-deps
  → npm run build → npm run dist --publish=always
  → upload-artifact (retention 30 days)
Auth:    GH_TOKEN = secrets.GITHUB_TOKEN  (no extra secret needed)
```

**Architecture — release flow:**

```
developer: git tag v1.2.3 && git push --tags
                    │
         ┌──────────▼──────────┐
         │  release.yml fires  │
         └──────┬──────┬───────┘
          win   │  lin │  mac
          ──────▼  ─────▼  ────▼
         build  build  build
          │        │      │
          └────────┴──────┘
                   │
          gh release (auto-draft)
          ├── Rein-Setup-1.2.3.exe
          ├── Rein-1.2.3.AppImage
          └── Rein-1.2.3.dmg
```

---

## What the full GSoC implementation will add

- Code-signing: Windows (signtool), macOS (notarytool), Linux (GPG)
- Auto-update via `electron-updater` — in-app update prompts
- Flatpak manifest publishing to Flathub (see also #206)
- Snap packaging for Ubuntu Software Center
- SHA256 checksum file alongside every release
- Release notes auto-generated from conventional commits
- `build.yml` gating: release only runs if CI passes

---

## Testing

Locally verified:
- `electron/main.cjs` loads without error (`npm run electron`)
- Config files now created under `%APPDATA%\Rein\` (Windows) / `~/.config/Rein/` (Linux)
- `release.yml` YAML is valid (checked with `actionlint`)

---

> **Note**: This PR is closed immediately as a proposal artifact. The complete implementation will be submitted during GSoC 2026 coding period.