### PR TITLE
fix: change audioback to audioprev in ExtraKeys

### DIFF
--- a/src/components/Trackpad/ExtraKeys.tsx
+++ b/src/components/Trackpad/ExtraKeys.tsx
@@ -40,7 +40,7 @@ export const ExtraKeys: React.FC<ExtraKeysProps> = ({ sendKey }) => {
 		{ icon: <FaVolumeUp />, key: "audiovolup", type: "media", label: "Vol Up" },
 		{
 			icon: <FaBackward />,
-			key: "audioback",
+			key: "audioprev",
 			type: "media",
 			label: "Backward",
 		},


### PR DESCRIPTION
## Summary
- Fix broken backward media button in ExtraKeys component
- Changed key from "audioback" (non-existent) to "audioprev" (maps to Key.AudioPrev)
- One-line fix, high impact

Closes #307