### PR TITLE
fix: guard JSON.parse in trackpad localStorage read

### DIFF
--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -33,7 +33,11 @@ function TrackpadPage() {
 	const [invertScroll] = useState(() => {
 		if (typeof window === "undefined") return false
 		const s = localStorage.getItem("rein_invert")
-		return s ? JSON.parse(s) : false
+		try {
+			return s ? JSON.parse(s) : false
+		} catch {
+			return false
+		}
 	})
 
 	const { send, sendCombo } = useRemoteConnection()


### PR DESCRIPTION
## Summary
- Wrap JSON.parse in try/catch to prevent component crash
- Occurs when reading "rein_invert" from localStorage

Closes #308