### PR TITLE
fix: clear video srcObject in stopSharing to prevent GPU leak

### DIFF
--- a/src/hooks/useCaptureProvider.ts
+++ b/src/hooks/useCaptureProvider.ts
@@ -18,6 +18,10 @@ export function useCaptureProvider(wsRef: React.RefObject<WebSocket | null>) {
 			for (const track of streamRef.current.getTracks()) track.stop()
 			streamRef.current = null
 		}
+		if (videoRef.current) {
+			videoRef.current.pause()
+			videoRef.current.srcObject = null
+		}
 		if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
 			wsRef.current.send(JSON.stringify({ type: "stop-mirror" }))
 		}


### PR DESCRIPTION
## Summary
- Clear video element's srcObject and pause when stopping screen sharing
- Prevents GPU pipeline memory leak

Closes #310