### PR TITLE
fix: strip token from URL after storing in localStorage

### DIFF
--- a/src/contexts/ConnectionProvider.tsx
+++ b/src/contexts/ConnectionProvider.tsx
@@ -78,6 +78,14 @@ export function ConnectionProvider({
 			} catch (e) {
 				// Failed to store
 			}
+			// Remove token from URL to prevent it persisting in browser history
+			try {
+				const cleanUrl = new URL(window.location.href)
+				cleanUrl.searchParams.delete("token")
+				window.history.replaceState(null, "", cleanUrl.toString())
+			} catch (e) {
+				// Best-effort
+			}
 		}
 
 		let wsUrl = `${protocol}//${host}/ws`


### PR DESCRIPTION
## Summary
- Remove auth token from browser URL after storing in localStorage
- Prevents token from persisting in browser history
- Critical security fix

Closes #311