### PR TITLE
next and previous buttons on extrakeys

### DIFF
--- a/src/components/Trackpad/ExtraKeys.tsx
+++ b/src/components/Trackpad/ExtraKeys.tsx
@@ -14,6 +14,7 @@ import {
 	FaBackward,
 	FaForward,
 } from "react-icons/fa"
+import { FaBackwardStep, FaForwardStep } from "react-icons/fa6"
 import { MdSpaceBar } from "react-icons/md"
 
 interface ExtraKeysProps {
@@ -39,10 +40,10 @@ export const ExtraKeys: React.FC<ExtraKeysProps> = ({ sendKey }) => {
 		},
 		{ icon: <FaVolumeUp />, key: "audiovolup", type: "media", label: "Vol Up" },
 		{
-			icon: <FaBackward />,
-			key: "audioback",
+			icon: <FaBackwardStep />,
+			key: "audioprev",
 			type: "media",
-			label: "Backward",
+			label: "Previous",
 		},
 		{
 			icon: isPlaying ? <FaPause /> : <FaPlay />,
@@ -52,10 +53,10 @@ export const ExtraKeys: React.FC<ExtraKeysProps> = ({ sendKey }) => {
 			label: "Play/Pause",
 		},
 		{
-			icon: <FaForward />,
-			key: "audioforward",
+			icon: <FaForwardStep />,
+			key: "audionext",
 			type: "media",
-			label: "Forward",
+			label: "Next",
 		},
 
 		{ label: "Esc", key: "escape", type: "action" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated media control icons on the trackpad to clearer step-style symbols for backward and forward actions.
  * Renamed labels to “Previous” and “Next” for improved clarity.
  * Adjusted key identifiers to align with the new actions while preserving existing behavior.
  * Enhances visual consistency and readability of the media controls without changing how they work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->