### PR TITLE
Fix: Add error handling for JSON.parse in trackpad component

### DIFF
--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -33,7 +33,12 @@ function TrackpadPage() {
 	const [invertScroll] = useState(() => {
 		if (typeof window === "undefined") return false
 		const s = localStorage.getItem("rein_invert")
-		return s ? JSON.parse(s) : false
+		if (!s) return false
+		try {
+			return JSON.parse(s)
+		} catch {
+			return false
+		}
 	})
 
 	const { send, sendCombo } = useRemoteConnection()


### PR DESCRIPTION
## Description
Fixes Issue #308 - JSON.parse without try/catch crashes trackpad component

## Changes
- Added try/catch error handling around `JSON.parse()` when reading `rein_invert` from localStorage
- Prevents component crash when localStorage contains malformed JSON data
- Returns safe default value (false) on parsing error

## Testing
- ? Tested with valid localStorage data
- ? Tested with malformed JSON data - no crash
- ? Tested with null/undefined localStorage - returns default

## Related Issue
Closes #308

---

**First-time contributor** ?? - Excited to contribute to AOSSIE!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of trackpad scroll inversion settings by adding robust error handling for corrupted or missing configuration data, preventing potential application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->