### PR TITLE
Fix: Clean up video element to prevent GPU memory leak

### DIFF
--- a/src/hooks/useCaptureProvider.ts
+++ b/src/hooks/useCaptureProvider.ts
@@ -18,6 +18,10 @@ export function useCaptureProvider(wsRef: React.RefObject<WebSocket | null>) {
 			for (const track of streamRef.current.getTracks()) track.stop()
 			streamRef.current = null
 		}
+		if (videoRef.current) {
+			videoRef.current.pause()
+			videoRef.current.srcObject = null
+		}
 		if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
 			wsRef.current.send(JSON.stringify({ type: "stop-mirror" }))
 		}


### PR DESCRIPTION
## Description
Fixes Issue #310 - Video element not cleaned up in stopSharing causes GPU leak

## Changes
- Added `video.pause()` to stop video playback
- Added `video.srcObject = null` to release GPU pipeline resources
- Prevents GPU memory leak when screen capture stops

## Testing
- ? Tested starting and stopping screen capture
- ? Verified video element is properly cleaned up
- ? Confirmed GPU resources are released after stopSharing

## Technical Details
The `stopSharing` function was cleaning up the timer and MediaStream tracks, but the video element itself remained active with its srcObject still set. This prevented the browser from releasing GPU pipeline memory allocated for video decoding.

## Related Issue
Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when stopping screen sharing to ensure media streams are fully detached and no longer consuming system resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->