### PR TITLE
Fix: Clear draggingTimeout on unmount to prevent timer leak

### DIFF
--- a/src/hooks/useTrackpadGesture.ts
+++ b/src/hooks/useTrackpadGesture.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
 	PINCH_THRESHOLD,
 	TOUCH_MOVE_THRESHOLD,
@@ -253,6 +253,14 @@ export const useTrackpadGesture = (
 			releasedCount.current = 0
 		}
 	}
+
+	useEffect(() => {
+		return () => {
+			if (draggingTimeout.current) {
+				clearTimeout(draggingTimeout.current)
+			}
+		}
+	}, [])
 
 	return {
 		isTracking,


### PR DESCRIPTION
## Description
Fixes Issue #309 - draggingTimeout not cleared on unmount in useTrackpadGesture

## Changes
- Added `useEffect` cleanup function to clear `draggingTimeout` on component unmount
- Prevents timer memory leak and potential errors from stale references

## Testing
- ? Tested component mount and unmount
- ? Verified timeout is properly cleared on cleanup
- ? Confirmed no timer leaks after unmount

## Technical Details
The `draggingTimeout` was set in `handleTouchEnd` (line 243) but never cleaned up when the component unmounts. This could cause:
1. Timer continuing to run after component is unmounted
2. Memory leak from uncancelled timer
3. Potential errors if timeout callback accesses stale component state

The fix adds a standard React cleanup pattern with `useEffect` to ensure the timeout is cleared on unmount.

## Related Issue
Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where gesture-related timeout handlers could execute after component unmount, preventing potential memory leaks and unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->