### PR TITLE
Fix: Add retry limit and signal handlers to prevent Electron hang

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -28,12 +28,20 @@ if (!gotLock) {
 }
 
 // Wait until server is ready
-function waitForServer(url) {
-  return new Promise((resolve) => {
+function waitForServer(url, maxRetries = 60) {
+  return new Promise((resolve, reject) => {
+    let attempts = 0;
     const check = () => {
+      attempts++;
       http
         .get(url, () => resolve())
-        .on('error', () => setTimeout(check, 500));
+        .on('error', () => {
+          if (attempts >= maxRetries) {
+            reject(new Error(`Server failed to start after ${maxRetries} attempts (${maxRetries * 0.5}s)`));
+          } else {
+            setTimeout(check, 500);
+          }
+        });
     };
     check();
   });
@@ -41,7 +49,7 @@ function waitForServer(url) {
 
 // Start Nitro server (production)
 function startServer() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const serverPath = path.join(
       process.resourcesPath,
       'app.asar.unpacked',
@@ -62,7 +70,9 @@ function startServer() {
       },
     });
 
-    waitForServer(`http://localhost:${serverPort}`).then(resolve);
+    waitForServer(`http://localhost:${serverPort}`)
+      .then(resolve)
+      .catch(reject);
   });
 }
 
@@ -91,12 +101,30 @@ function createWindow() {
 
 // App start
 app.whenReady().then(async () => {
-  await startServer();
-  createWindow();
+  try {
+    await startServer();
+    createWindow();
+  } catch (error) {
+    console.error('Failed to start server:', error.message);
+    app.quit();
+  }
 });
 
 // Cleanup
 app.on('window-all-closed', () => {
   if (serverProcess) serverProcess.kill();
   if (process.platform !== 'darwin') app.quit();
+});
+
+// Handle process termination signals for clean shutdown
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM, shutting down gracefully');
+  if (serverProcess) serverProcess.kill();
+  app.quit();
+});
+
+process.on('SIGINT', () => {
+  console.log('Received SIGINT, shutting down gracefully');
+  if (serverProcess) serverProcess.kill();
+  app.quit();
 });


### PR DESCRIPTION
## Description
Fixes Issue #312 - Electron hangs forever if Nitro server fails to start

## Changes

### 1. Added Retry Limit to waitForServer
- Added maxRetries parameter (default 60 attempts = 30 seconds)
- Added attempts counter to track retry count
- Rejects promise with descriptive error after max retries
- Prevents infinite hang when server fails to start

### 2. Added Error Handling
- Updated startServer to propagate rejection
- Added try/catch in app.whenReady() to handle startup failures
- App gracefully quits with error message instead of hanging

### 3. Added Signal Handlers
- Added SIGTERM handler for graceful shutdown
- Added SIGINT handler for interrupt handling
- Both handlers properly kill server process before quitting

## Testing
- Tested with working Nitro server - starts normally
- Tested with missing server file - quits after 30s with error
- Tested SIGTERM signal - clean shutdown
- Tested SIGINT (Ctrl+C) - clean shutdown

## Technical Details

Before: waitForServer would retry indefinitely every 500ms. If Nitro crashed or failed to start, Electron would hang forever with no feedback to the user.

After: Retries for maximum 30 seconds (60 attempts × 500ms), shows error message, quits gracefully, and properly handles termination signals for clean process shutdown.

## Related Issue
Closes #312