### PR TITLE
fix: Support both development and production builds in Electron

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -39,10 +39,14 @@ function waitForServer(url) {
   });
 }
 
-// Start Nitro server (production)
+// Start Nitro server (development or production)
 function startServer() {
   return new Promise((resolve) => {
-    const serverPath = path.join(
+    // Try development path first (after npm run build)
+    const devPath = path.join(process.cwd(), '.output', 'server', 'index.mjs');
+
+    // Fallback to production path (after npm run dist)
+    const prodPath = path.join(
       process.resourcesPath,
       'app.asar.unpacked',
       '.output',
@@ -50,11 +54,29 @@ function startServer() {
       'index.mjs'
     );
 
-    console.log("Starting server from:", serverPath);
+    // Determine which path to use
+    let serverPath;
+    let isDevelopment = false;
+
+    if (fs.existsSync(devPath)) {
+      serverPath = devPath;
+      isDevelopment = true;
+      console.log("Starting server in DEVELOPMENT mode from:", serverPath);
+    } else if (fs.existsSync(prodPath)) {
+      serverPath = prodPath;
+      console.log("Starting server in PRODUCTION mode from:", serverPath);
+    } else {
+      console.error("ERROR: Server build not found!");
+      console.error("Tried development path:", devPath);
+      console.error("Tried production path:", prodPath);
+      console.error("Please run 'npm run build' first.");
+      app.quit();
+      return;
+    }
 
     serverProcess = spawn('node', [serverPath], {
-      stdio: 'ignore',       // no terminal
-      windowsHide: true,     // hide CMD
+      stdio: isDevelopment ? 'inherit' : 'ignore',  // show logs in dev
+      windowsHide: !isDevelopment,                  // show terminal in dev
       env: {
         ...process.env,
         HOST: serverHost,


### PR DESCRIPTION
## Description
Fixes Issue #284 - npm run electron not working after development builds

Added intelligent path detection to support running the Electron app after both development builds (`npm run build`) and production packages (`npm run dist`).

## Problem

Developers were forced to run `npm run dist` (full packaging) to test even small changes because `npm run electron` only worked with packaged builds. This made the development workflow extremely slow and painful:

**Before:**
1. Make a small code change
2. Run `npm run build` (✅ works)
3. Run `npm run electron` (❌ fails - can't find server)
4. Run `npm run dist` (😢 slow, packages entire app)
5. Test the change

This cycle took several minutes for each iteration, making rapid development nearly impossible.

## Solution

Implemented smart path detection that checks for both development and production server locations:

### Path Detection Logic

1. **Development Path** (checked first):
   - Location: `process.cwd()/.output/server/index.mjs`
   - Used after: `npm run build`
   - Enables: Fast iteration during development

2. **Production Path** (fallback):
   - Location: `app.asar.unpacked/.output/server/index.mjs`
   - Used after: `npm run dist`
   - Preserves: Original packaging behavior

3. **Error Handling**:
   - Clear messages if neither path exists
   - Instructs user to run `npm run build` first
   - Gracefully quits instead of hanging

### Development Mode Features

When development build is detected:
- **Server Logs Visible**: `stdio: 'inherit'` shows all server output
- **Terminal Window Shown**: `windowsHide: false` for debugging
- **Faster Debugging**: See errors and warnings immediately

When production build is detected:
- **Original Behavior Preserved**: Hidden logs and terminal
- **Clean User Experience**: No developer noise

## Workflow Improvements

**After this fix:**
1. Make a code change
2. Run `npm run build` (builds in seconds)
3. Run `npm run electron` (✅ works!)
4. Test immediately
5. Repeat

Development iteration time reduced from **minutes to seconds**.

## Technical Details

### File: electron/main.cjs

**Changes made:**
- Added `devPath` variable for development builds
- Added `prodPath` variable for production builds
- Added `isDevelopment` flag to track current mode
- Modified `spawn` options based on mode:
  - `stdio`: 'inherit' (dev) vs 'ignore' (prod)
  - `windowsHide`: false (dev) vs true (prod)
- Added comprehensive error handling and logging

**Lines Changed:** +27/-5

## Testing Scenarios

### Development Mode
```bash
npm run build
npm run electron  # ✅ Now works!
```

### Production Mode
```bash
npm run dist
# Run the packaged executable  # ✅ Still works!
```

### Error Handling
```bash
npm run electron  # Without building first
# Shows clear error message
# Instructs to run 'npm run build'
```

## Impact

### For Contributors
- **Faster iteration**: Test changes in seconds instead of minutes
- **Better debugging**: See server logs during development
- **Lower barrier**: No need to understand packaging process
- **Reduced frustration**: Instant feedback on changes

### For Project
- **More contributions**: Easier development encourages participation
- **Better code quality**: Faster testing enables more thorough validation
- **Improved onboarding**: New contributors can iterate quickly

### Backwards Compatibility
- **Production builds**: Unchanged behavior (hidden logs/terminal)
- **Existing workflows**: All `npm run dist` usage still works
- **CI/CD**: No impact on automated builds

## Related Issues

Closes #284

## Notes

This change significantly improves the developer experience for anyone contributing to Rein. The ability to quickly test changes without full packaging is essential for productive development.