### PR TITLE
fix: prevent app hang when server fails to start

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -33,15 +33,22 @@ function waitForServer(url, timeout = 15000) {
     const start = Date.now();
 
     const check = () => {
-      http
-        .get(url, () => resolve())
-        .on('error', () => {
-          if (Date.now() - start > timeout) {
-            reject(new Error('Server did not start within timeout'));
-          } else {
-            setTimeout(check, 500);
-          }
-        });
+      const req = http.get(url, (res) => {
+        res.resume();
+        resolve();
+      });
+
+      req.setTimeout(2000, () => {
+        req.destroy();
+      });
+
+      req.on('error', () => {
+        if (Date.now() - start > timeout) {
+          reject(new Error('Server did not start within timeout'));
+        } else {
+          setTimeout(check, 500);
+        }
+      });
     };
 
     check();
@@ -111,6 +118,7 @@ app.whenReady().then(async () => {
     createWindow();
   } catch (e) {
     console.error('Startup failed:', e);
+    if (serverProcess) serverProcess.kill();
     app.quit();
   }
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -28,20 +28,29 @@ if (!gotLock) {
 }
 
 // Wait until server is ready
-function waitForServer(url) {
-  return new Promise((resolve) => {
+function waitForServer(url, timeout = 15000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+
     const check = () => {
       http
         .get(url, () => resolve())
-        .on('error', () => setTimeout(check, 500));
+        .on('error', () => {
+          if (Date.now() - start > timeout) {
+            reject(new Error('Server did not start within timeout'));
+          } else {
+            setTimeout(check, 500);
+          }
+        });
     };
+
     check();
   });
 }
 
 // Start Nitro server (production)
 function startServer() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const serverPath = path.join(
       process.resourcesPath,
       'app.asar.unpacked',
@@ -62,7 +71,13 @@ function startServer() {
       },
     });
 
-    waitForServer(`http://localhost:${serverPort}`).then(resolve);
+    waitForServer(`http://localhost:${serverPort}`)
+      .then(resolve)
+      .catch((err) => {
+        console.error('Server failed to start:', err);
+        if (serverProcess) serverProcess.kill();
+        reject(err)
+      });
   });
 }
 
@@ -91,8 +106,13 @@ function createWindow() {
 
 // App start
 app.whenReady().then(async () => {
-  await startServer();
-  createWindow();
+  try {
+    await startServer();
+    createWindow();
+  } catch (e) {
+    console.error('Startup failed:', e);
+    app.quit();
+  }
 });
 
 // Cleanup


### PR DESCRIPTION
### Description
Fixes an issue where the app would hang indefinitely if the backend server failed to start.

- Added timeout to server readiness check
- Properly reject promise on failure
- Handle startup errors to avoid silent freeze

### Functional Verification
- Verified app exits cleanly when server fails to start
- Success case (normal startup) not fully verified in Electron runtime

### Additional Notes
This change only affects Electron main process startup flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 15-second timeout for server startup to prevent the application from hanging indefinitely if the server fails to start.
  * Improved error handling during app initialization with graceful shutdown when server startup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->