### PR TITLE
fix: resolve `npm ci` failures caused by `lockfile` mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9409,46 +9409,6 @@
 				}
 			}
 		},
-		"node_modules/nitro-nightly/node_modules/chokidar": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/nitro-nightly/node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-			"extraneous": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/nitro-nightly/node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"extraneous": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/nitro-nightly/node_modules/unstorage": {
 			"version": "2.0.0-alpha.7",
 			"resolved": "https://registry.npmjs.org/unstorage/-/unstorage-2.0.0-alpha.7.tgz",
@@ -9549,46 +9509,6 @@
 				"uploadthing": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/nitro/node_modules/chokidar": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/nitro/node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-			"extraneous": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/nitro/node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"extraneous": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/nitro/node_modules/unstorage": {
@@ -10101,6 +10021,28 @@
 			"dependencies": {
 				"xml-parse-from-string": "^1.0.0",
 				"xml2js": "^0.5.0"
+			}
+		},
+		"node_modules/parse-bmfont-xml/node_modules/xml2js": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/parse-bmfont-xml/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/parse-headers": {
@@ -13052,28 +12994,6 @@
 			"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
 			"integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
 			"license": "MIT"
-		},
-		"node_modules/xml2js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-			"license": "MIT",
-			"dependencies": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/xml2js/node_modules/xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			}
 		},
 		"node_modules/xmlbuilder": {
 			"version": "15.1.1",


### PR DESCRIPTION
## Summary

This PR resolves CI failures caused by inconsistencies between `package.json` and `package-lock.json`.

## Changes

* Updated `package-lock.json` to match the current dependency tree.
* Resolved missing dependency entries reported during `npm ci`.

## Verification

* Successfully ran `npm ci`.
* Successfully ran `npm run build`.
* Confirmed that dependency installation completes without lockfile synchronization errors.

Fixes #354 