### PR TITLE
 add NixOS setup instructions and improve shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A cross-platform, remote desktop (started as a couch keyboard replacement utiliz
 
 ## Why?
 
-Quality couch keyboards are not so accessible, STT on Linux isn’t in a good state, so we can take advantage of STT on mobile, plus use the phone as a controller for casual gaming.
+Quality couch keyboards are not so accessible, STT on Linux isn't in a good state, so we can take advantage of STT on mobile, plus use the phone as a controller for casual gaming.
 
 ## Tech Stack
 
@@ -27,17 +27,58 @@ Quality couch keyboards are not so accessible, STT on Linux isn’t in a good st
 > [!NOTE]
 > **For Linux:** On Wayland, the `ydotoold` daemon must be running and your user must be part of the `ydotool` group. Additionally, some native dependencies are required : install them via your package manager (see [`shell.nix`](shell.nix) for the list), or use `nix-shell` directly.
 
+### NixOS
+
+Rein provides a `shell.nix` for a fully reproducible NixOS development environment.
+
+**Enter the dev shell:**
+```bash
+nix-shell
+```
+
+This sets up all required native libraries and makes `ydotool`, `appimage-run`, and `nodejs_24` available automatically.
+
+**Wayland input setup (one time only):**
+```bash
+# Add your user to the ydotool group
+sudo usermod -aG ydotool $USER
+
+# Re-login, then enable the daemon
+sudo systemctl enable --now ydotoold
+```
+
+**Running the built AppImage on NixOS:**
+```bash
+npm run dist
+appimage-run ./dist/Rein-*.AppImage
+```
+
+**Firewall (nftables):**
+
+Add to your `configuration.nix`, then run `sudo nixos-rebuild switch`:
+```nix
+networking.firewall.allowedTCPPorts = [ 3000 ];
+```
+
+**Troubleshooting:**
+
+| Error | Fix |
+|-------|-----|
+| `Failed to open /dev/uinput` | Run `sudo systemctl start ydotoold` |
+| `error while loading shared libraries: libX11.so` | Make sure you are inside `nix-shell` |
+| Electron crashes on launch | `LD_LIBRARY_PATH` must be set — the `shellHook` does this automatically |
+| AppImage won't start | Use `appimage-run ./dist/Rein-*.AppImage`, not `./dist/Rein-*.AppImage` directly |
 
 ### Quick Start
 
 1.  Install dependencies:
-    ```bash
+```bash
     npm install
-    ```
+```
 2.  Start the development server:
-    ```bash
+```bash
     npm run dev
-    ```
+```
 3.  Open the local app: `http://localhost:3000`
 
 ## How to Use (Remote Control)
@@ -69,7 +110,6 @@ Visit the [Discord Channel](https://discord.com/invite/C8wHmwtczs) for interacti
 
 ---
 
-
 ## Testing Rein on Virtual Machines
 
 When testing Rein inside a Virtual Machine (VirtualBox), the VM must allow devices on the same network to access the server.
@@ -86,7 +126,6 @@ This allows devices on the same LAN to connect to the Rein server running inside
 ### For MacOS
 
 Grant Accessibility permission to your terminal/IDE in System Settings → Privacy & Security → Accessibility.
-
 
 ---
 
@@ -199,5 +238,3 @@ flowchart TD
 | **Client settings** | Sensitivity, scroll invert, and theme are stored in `localStorage` on the phone only — no server round-trip. |
 | **Server settings** | Port changes call `POST /api/config`, which writes `server-config.json`. The client redirects to the new port URL. The change is picked up on the next server start. |
 | **Input injection** | Input events arrive at the server via the DataChannel bridge, dispatched through `InputHandler` (throttle + validation), and injected at OS level via a virtual input device. |
-
-

--- a/shell.nix
+++ b/shell.nix
@@ -12,24 +12,35 @@ let
     libxtst
     libx11
     libxext
+    libxrandr
+    libxcomposite
+    libxdamage
+    libxfixes
     git
   ];
 in
+
 pkgs.mkShell {
   buildInputs = with pkgs; [
     nodejs_24
     procps
     appimage-run
+    ydotool
   ] ++ sharedLibs;
 
   shellHook = ''
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath sharedLibs}:$LD_LIBRARY_PATH
     alias g="git"
-    # git clone https://github.com/AOSSIE-Org/Rein .
-    npm i
-    npm run dist
-    appimage-run ./dist/Rein-1.0.0.AppImage
-    # npm run electron-dev
+
+    echo ""
+    echo "=== Rein NixOS Dev Shell ==="
+    echo "Run 'npm install'                                          to install dependencies"
+    echo "Run 'npm run dev'                                          to start the dev server"
+    echo "Run 'npm run dist && appimage-run ./dist/Rein-*.AppImage'  to build and run"
+    echo ""
+    echo "NOTE (Wayland): Ensure ydotoold is running and your user is in the 'ydotool' group:"
+    echo "  sudo usermod -aG ydotool \$USER  (then re-login)"
+    echo "  sudo systemctl start ydotoold"
+    echo ""
   '';
 }
-


### PR DESCRIPTION
Closes #338

   ## Changes

   ### README.md
   - Added a dedicated NixOS section with:
     - nix-shell quickstart
     - Wayland ydotoold group setup steps
     - AppImage execution via appimage-run
     - nftables firewall configuration
     - Troubleshooting table for common errors

   ### shell.nix
   - Removed auto-run commands from shellHook (npm i + npm run dist ran on every shell entry, breaking dev workflow)
   - Added ydotool to buildInputs (required for Wayland input simulation)
   - Added missing Electron X11 libs: libxrandr, libxcomposite, libxdamage, libxfixes
   - Replaced hardcoded Rein-1.0.0.AppImage with wildcard Rein-*.AppImage
   - Added helpful echo guidance so new NixOS contributors know what commands to run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded development setup guidance with comprehensive NixOS workflow including Wayland configuration and troubleshooting.
  * Added MacOS accessibility permissions guidance for terminal and IDE access.
  * Improved Quick Start instructions with enhanced code formatting.

* **Chores**
  * Updated development environment configuration with additional X11 runtime libraries and setup instruction messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->