### PR TITLE
feat: keep mobile screen awake while using trackpad (#78)

### DIFF
--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -64,6 +64,47 @@ function TrackpadPage() {
 		}
 	}, [keyboardOpen])
 
+	// Keep the mobile screen awake while using the trackpad
+	useEffect(() => {
+		let wakeLock: WakeLockSentinel | null = null
+
+		const requestWakeLock = async () => {
+			if (typeof window !== "undefined" && "wakeLock" in navigator) {
+				try {
+					wakeLock = await navigator.wakeLock.request("screen")
+					console.log("[WakeLock] Screen Wake Lock acquired")
+				} catch (err) {
+					console.warn("[WakeLock] Failed to acquire screen wake lock:", err)
+				}
+			}
+		}
+
+		requestWakeLock()
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "visible") {
+				requestWakeLock()
+			}
+		}
+
+		document.addEventListener("visibilitychange", handleVisibilityChange)
+
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange)
+			if (wakeLock) {
+				wakeLock
+					.release()
+					.then(() => {
+						wakeLock = null
+						console.log("[WakeLock] Screen Wake Lock released")
+					})
+					.catch((err) => {
+						console.error("[WakeLock] Failed to release wake lock:", err)
+					})
+			}
+		}
+	}, [])
+
 	const toggleKeyboard = () => setKeyboardOpen((prev) => !prev)
 	const focusInput = () => hiddenInputRef.current?.focus()
 

--- a/src/routes/trackpad.tsx
+++ b/src/routes/trackpad.tsx
@@ -67,15 +67,31 @@ function TrackpadPage() {
 	// Keep the mobile screen awake while using the trackpad
 	useEffect(() => {
 		let wakeLock: WakeLockSentinel | null = null
+		let isMounted = true
 
 		const requestWakeLock = async () => {
-			if (typeof window !== "undefined" && "wakeLock" in navigator) {
-				try {
-					wakeLock = await navigator.wakeLock.request("screen")
-					console.log("[WakeLock] Screen Wake Lock acquired")
-				} catch (err) {
-					console.warn("[WakeLock] Failed to acquire screen wake lock:", err)
+			if (typeof window === "undefined" || !("wakeLock" in navigator)) {
+				return
+			}
+			if (wakeLock && !wakeLock.released) {
+				return
+			}
+
+			try {
+				const sentinel = await navigator.wakeLock.request("screen")
+
+				if (!isMounted) {
+					sentinel.release().catch(() => {})
+					return
 				}
+
+				if (wakeLock && !wakeLock.released) {
+					wakeLock.release().catch(() => {})
+				}
+
+				wakeLock = sentinel
+			} catch (err) {
+				console.warn("[WakeLock] Failed to acquire screen wake lock:", err)
 			}
 		}
 
@@ -90,17 +106,10 @@ function TrackpadPage() {
 		document.addEventListener("visibilitychange", handleVisibilityChange)
 
 		return () => {
+			isMounted = false
 			document.removeEventListener("visibilitychange", handleVisibilityChange)
-			if (wakeLock) {
-				wakeLock
-					.release()
-					.then(() => {
-						wakeLock = null
-						console.log("[WakeLock] Screen Wake Lock released")
-					})
-					.catch((err) => {
-						console.error("[WakeLock] Failed to release wake lock:", err)
-					})
+			if (wakeLock && !wakeLock.released) {
+				wakeLock.release().catch(() => {})
 			}
 		}
 	}, [])


### PR DESCRIPTION
### Addressed Issues:
Fixes #78

### Description
This PR implements the browser's native **Screen Wake Lock API** in the trackpad component. When using the mobile device as a remote trackpad, the screen will no longer dim, sleep, or auto-lock.

Key additions:
- **Acquires screen wake lock** automatically when the trackpad page mounts.
- **Handles tab visibility changes**: Automatically re-acquires the lock if the user tabs away and returns to the trackpad view.
- **Automatic Cleanup**: Properly releases the screen lock when the component unmounts (leaving the trackpad route) to preserve the client's battery life.
- **Type Safety**: Strictly typed with native DOM `WakeLockSentinel` types (fully passes the Biome linter and TypeScript compiler checks).

### Screenshots/Recordings:
*(Not applicable as this is a non-visual background API change)*

## Functional Verification
- Please check off the behaviors verified with this change.

### Screen Mirror
- [ ] Screen Mirror works.

### Authentication
- [ ] Connection doesn't work without a valid token.

### Basic Gestures
- [ ] One-finger tap: Verified as Left Click.
- [ ] Two-finger tap: Verified as Right Click.
- [ ] Click and drag: Verified selection behavior.
- [ ] Pinch to zoom: Verified zoom functionality (if applicable).

### Modes & Settings
- [ ] Cursor mode: Cursor moves smoothly and accurately.
- [ ] Scroll mode: Page scrolls as expected.
- [ ] Sensitivity: Verified changes in cursor speed/sensitivity settings.
- [ ] Copy and Paste: Verified both Copy and Paste functionality.
- [ ] Invert Scrolling: Verified scroll direction toggles correctly.

### Advanced Input
- [ ] Key combinations: Verified "hold" behavior for modifiers (e.g., Ctrl+C) and held keys are shown in buffer.
- [ ] Keyboard input: Verified Space, Backspace, and Enter keys work correctly.
- [ ] Glide typing: Verified path drawing and text output.
- [ ] Voice input: Verified speech-to-text functionality for full sentences.
- [ ] Backspace doesn't send the previous input.

### Any other gesture or input behavior introduced:
- [x] New Gestures: Verified screen wake lock remains active and prevents phone sleep during usage.

### Additional Notes:
The Screen Wake Lock API is supported on Chrome, Edge, Opera, and Safari (iOS 13.7+). A warning fallback (`console.warn`) is included for unsupported browser contexts to avoid app failures.

### Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [ ] I have joined the Discord and I will share a link to this PR with the project maintainers there
- [x] I have read the Contributing guidelines
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ ] Incase of UI change I've added a demo video.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The trackpad now helps keep the device screen awake during use.
  * Screen wake protection is automatically restored when returning to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->