### PR TITLE
chore: upgrade TypeScript to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,6 +1130,37 @@
 				"node": ">=14.14"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+			"integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.3",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+			"integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.28.2",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
@@ -1784,6 +1815,27 @@
 				"node": "^22.20 || ^24.12 || >=25"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+			"integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+				"@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+			}
+		},
 		"node_modules/@neodrag/core": {
 			"version": "3.0.0-next.11",
 			"resolved": "https://registry.npmjs.org/@neodrag/core/-/core-3.0.0-next.11.tgz",
@@ -1900,6 +1952,350 @@
 				"node": ">=20.0"
 			}
 		},
+		"node_modules/@oxc-minify/binding-android-arm-eabi": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.110.0.tgz",
+			"integrity": "sha512-43fMTO8/5bMlqfOiNSZNKUzIqeLIYuB9Hr1Ohyf58B1wU11S2dPGibTXOGNaWsfgHy99eeZ1bSgeIHy/fEYqbw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-android-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.110.0.tgz",
+			"integrity": "sha512-5oQrnn9eK/ccOp80PTrNj0Vq893NPNNRryjGpOIVsYNgWFuoGCfpnKg68oEFcN8bArizYAqw4nvgHljEnar69w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-darwin-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.110.0.tgz",
+			"integrity": "sha512-dqBDgTG9tF2z2lrZp9E8wU+Godz1i8gCGSei2eFKS2hRploBOD5dmOLp1j4IMornkPvSQmbwB3uSjPq7fjx4EA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-darwin-x64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.110.0.tgz",
+			"integrity": "sha512-U0AqabqaooDOpYmeeOye8wClv8PSScELXgOfYqyqgrwH9J9KrpCE1jL8Rlqgz68QbL4mPw3V6sKiiHssI4CLeQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-freebsd-x64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.110.0.tgz",
+			"integrity": "sha512-H0w8o/Wo1072WSdLfhwwrpFpwZnPpjQODlHuRYkTfsSSSJbTxQtjJd4uxk7YJsRv5RQp69y0I7zvdH6f8Xueyw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.110.0.tgz",
+			"integrity": "sha512-qd6sW0AvEVYZhbVVMGtmKZw3b1zDYGIW+54Uh42moWRAj6i4Jhk/LGr6r9YNZpOINeuvZfkFuEeDD/jbu7xPUA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.110.0.tgz",
+			"integrity": "sha512-7WXP0aXMrWSn0ScppUBi3jf68ebfBG0eri8kxLmBOVSBj6jw1repzkHMITJMBeLr5d0tT/51qFEptiAk2EP2iA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.110.0.tgz",
+			"integrity": "sha512-LYfADrq5x1W5gs+u9OIbMbDQNYkAECTXX0ufnAuf3oGmO51rF98kGFR5qJqC/6/csokDyT3wwTpxhE0TkcF/Og==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.110.0.tgz",
+			"integrity": "sha512-53GjCVY8kvymk9P6qNDh6zyblcehF5QHstq9QgCjv13ONGRnSHjeds0PxIwiihD7h295bxsWs84DN39syLPH4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.110.0.tgz",
+			"integrity": "sha512-li8XcN81dxbJDMBESnTgGhoiAQ+CNIdM0QGscZ4duVPjCry1RpX+5FJySFbGqG3pk4s9ZzlL/vtQtbRzZIZOzg==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.110.0.tgz",
+			"integrity": "sha512-SweKfsnLKShu6UFV8mwuj1d1wmlNoL/FlAxPUzwjEBgwiT2HQkY24KnjBH+TIA+//1O83kzmWKvvs4OuEhdIEQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-riscv64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.110.0.tgz",
+			"integrity": "sha512-oH8G4aFMP8XyTsEpdANC5PQyHgSeGlopHZuW1rpyYcaErg5YaK0vXjQ4EM5HVvPm+feBV24JjxgakTnZoF3aOQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-s390x-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.110.0.tgz",
+			"integrity": "sha512-W9na+Vza7XVUlpf8wMt4QBfH35KeTENEmnpPUq3NSlbQHz8lSlSvhAafvo43NcKvHAXV3ckD/mUf2VkqSdbklg==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-x64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.110.0.tgz",
+			"integrity": "sha512-XJdA4mmmXOjJxSRgNJXsDP7Xe8h3gQhmb56hUcCrvq5d+h5UcEi2pR8rxsdIrS8QmkLuBA3eHkGK8E27D7DTgQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-x64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.110.0.tgz",
+			"integrity": "sha512-QqzvALuOTtSckI8x467R4GNArzYDb/yEh6aNzLoeaY1O7vfT7SPDwlOEcchaTznutpeS9Dy8gUS/AfqtUHaufw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-openharmony-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.110.0.tgz",
+			"integrity": "sha512-gAMssLs2Q3+uhLZxanh1DF+27Kaug3cf4PXb9AB7XK81DR+LVcKySXaoGYoOs20Co0fFSphd6rRzKge2qDK3dA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-wasm32-wasi": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.110.0.tgz",
+			"integrity": "sha512-7Wqi5Zjl022bs2zXq+ICdalDPeDuCH/Nhbi8q2isLihAonMVIT0YH2hqqnNEylRNGYck+FJ6gRZwMpGCgrNxPg==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-arm64-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.110.0.tgz",
+			"integrity": "sha512-ZPx+0Tj4dqn41ecyoGotlvekQKy6JxJCixn9Rw7h/dafZ3eDuBcEVh3c2ZoldXXsyMIt5ywI8IWzFZsjNedd5Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-ia32-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.110.0.tgz",
+			"integrity": "sha512-H0Oyd3RWBfpEyvJIrFK94RYiY7KKSQl11Ym7LMDwLEagelIAfRCkt1amHZhFa/S3ZRoaOJFXzEw4YKeSsjVFsg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-x64-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.110.0.tgz",
+			"integrity": "sha512-Hr3nK90+qXKJ2kepXwFIcNfQQIOBecB4FFCyaMMypthoEEhVP08heRynj4eSXZ8NL9hLjs3fQzH8PJXfpznRnQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.144.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
@@ -1909,101 +2305,445 @@
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
+		"node_modules/@oxc-transform/binding-android-arm-eabi": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.110.0.tgz",
+			"integrity": "sha512-sE9dxvqqAax1YYJ3t7j+h5ZSI9jl6dYuDfngl6ieZUrIy5P89/8JKVgAzgp8o3wQSo7ndpJvYsi1K4ZqrmbP7w==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-android-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.110.0.tgz",
+			"integrity": "sha512-nqtbP4aMCtsCZ6qpHlHaQoWVHSBtlKzwaAgwEOvR+9DWqHjk31BHvpGiDXlMeed6CVNpl3lCbWgygb3RcSjcfw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-darwin-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.110.0.tgz",
+			"integrity": "sha512-oeSeHnL4Z4cMXtc8V0/rwoVn0dgwlS9q0j6LcHn9dIhtFEdp3W0iSBF8YmMQA+E7sILeLDjsHmHE4Kp0sOScXw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-darwin-x64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.110.0.tgz",
+			"integrity": "sha512-nL9K5x7OuZydobAGPylsEW9d4APs2qEkIBLMgQPA+kY8dtVD3IR87QsTbs4l4DBQYyun/+ay6qVCDlxqxdX2Jg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-freebsd-x64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.110.0.tgz",
+			"integrity": "sha512-GS29zXXirDQhZEUq8xKJ1azAWMuUy3Ih3W5Bc5ddk12LRthO5wRLFcKIyeHpAXCoXymQ+LmxbMtbPf84GPxouw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.110.0.tgz",
+			"integrity": "sha512-glzDHak8ISyZJemCUi7RCvzNSl+MQ1ly9RceT2qRufhUsvNZ4C/2QLJ1HJwd2N6E88bO4laYn+RofdRzNnGGEA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.110.0.tgz",
+			"integrity": "sha512-8JThvgJ2FRoTVfbp7e4wqeZqCZbtudM06SfZmNzND9kPNu/LVYygIR+72RWs+xm4bWkuYHg/islo/boNPtMT5Q==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.110.0.tgz",
+			"integrity": "sha512-IRh21Ub/g4bkHoErZ0AUWMlWfoZaS0A6EaOVtbcY70RSYIMlrsbjiFwJCzM+b/1DD1rXbH5tsGcH7GweTbfRqg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-arm64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.110.0.tgz",
+			"integrity": "sha512-e5JN94/oy+wevk76q+LMr+2klTTcO60uXa+Wkq558Ms7mdF2TvkKFI++d/JeiuIwJLTi/BxQ4qdT5FWcsHM/ug==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.110.0.tgz",
+			"integrity": "sha512-Y3/Tnnz1GvDpmv8FXBIKtdZPsdZklOEPdrL6NHrN5i2u54BOkybFaDSptgWF53wOrJlTrcmAVSE6fRKK9XCM2Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.110.0.tgz",
+			"integrity": "sha512-Y0E35iA9/v9jlkNcP6tMJ+ZFOS0rLsWDqG6rU9z+X2R3fBFJBO9UARIK6ngx8upxk81y1TFR2CmBFhupfYdH6Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-riscv64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.110.0.tgz",
+			"integrity": "sha512-JOUSYFfHjBUs7xp2FHmZHb8eTYD/oEu0NklS6JgUauqnoXZHiTLPLVW2o2uVCqldnabYHcomuwI2iqVFYJNhTw==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.110.0.tgz",
+			"integrity": "sha512-7blgoXF9D3Ngzb7eun23pNrHJpoV/TtE6LObwlZ3Nmb4oZ6Z+yMvBVaoW68NarbmvNGfZ95zrOjgm6cVETLYBA==",
+			"cpu": [
+				"s390x"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-x64-gnu": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.110.0.tgz",
+			"integrity": "sha512-YQ2joGWCVDZVEU2cD/r/w49hVjDm/Qu1BvC/7zs8LvprzdLS/HyMXGF2oA0puw0b+AqgYaz3bhwKB2xexHyITQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-linux-x64-musl": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.110.0.tgz",
+			"integrity": "sha512-fkjr5qE632ULmNgvFXWDR/8668WxERz3tU7TQFp6JebPBneColitjSkdx6VKNVXEoMmQnOvBIGeP5tUNT384oA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-openharmony-arm64": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.110.0.tgz",
+			"integrity": "sha512-HWH9Zj+lMrdSTqFRCZsvDWMz7OnMjbdGsm3xURXWfRZpuaz0bVvyuZNDQXc4FyyhRDsemICaJbU1bgeIpUJDGw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-wasm32-wasi": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.110.0.tgz",
+			"integrity": "sha512-ejdxHmYfIcHDPhZUe3WklViLt9mDEJE5BzcW7+R1vc5i/5JFA8D0l7NUSsHBJ7FB8Bu9gF+5iMDm6cXGAgaghw==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.110.0.tgz",
+			"integrity": "sha512-9VTwpXCZs7xkV+mKhQ62dVk7KLnLXtEUxNS2T4nLz3iMl1IJbA4h5oltK0JoobtiUAnbkV53QmMVGW8+Nh3bDQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-win32-ia32-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.110.0.tgz",
+			"integrity": "sha512-5y0fzuNON7/F2hh2P94vANFaRPJ/3DI1hVl5rseCT8VUVqOGIjWaza0YS/D1g6t1WwycW2LWDMi2raOKoWU5GQ==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-transform/binding-win32-x64-msvc": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.110.0.tgz",
+			"integrity": "sha512-QROrowwlrApI1fEScMknGWKM6GTM/Z2xwMnDqvSaEmzNazBsDUlE08Jasw610hFEsYAVU2K5sp/YaCa9ORdP4A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@peculiar/asn1-cms": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
-			"integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.0.tgz",
+			"integrity": "sha512-VKQz6sJYgSxtGaK6UdnNBUx7hmSdg0K331qrEWh5qxpQsyZGWBjxbq05AJ2bTWWjd7d+nJIxFzwvsR5T7DWC/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
-				"@peculiar/asn1-x509-attr": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
+				"@peculiar/asn1-x509-attr": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-csr": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
-			"integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.0.tgz",
+			"integrity": "sha512-SbxRzHiWnRdiDuiiji/RLsJxu2au4hmSZSKK7GQOgNr2BVvheAlFQST9qqzRchUcZ6wvcyRuPXIfYXVzLoZ/5g==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-ecc": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
-			"integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.0.tgz",
+			"integrity": "sha512-vNspHtTd9h6e8c2lMW+B/VHEUD+HRFV0fj/Gvz7SaJbwiecA8dxd96UTFPYI1PR8k7qwjjW9AFEyI+LuyVi4Kw==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pfx": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
-			"integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.0.tgz",
+			"integrity": "sha512-A6bX+gZr69U38Pg1mWvPrM1eRba6L6kLR8iVG+bJtKj3qSv2rSNmlXLtej7ZOkEWt6xL6PiJD73uFEdQI3BXCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-cms": "^2.8.0",
-				"@peculiar/asn1-pkcs8": "^2.8.0",
-				"@peculiar/asn1-rsa": "^2.8.0",
-				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-cms": "^2.9.0",
+				"@peculiar/asn1-pkcs8": "^2.9.0",
+				"@peculiar/asn1-rsa": "^2.9.0",
+				"@peculiar/asn1-schema": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pkcs8": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
-			"integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.0.tgz",
+			"integrity": "sha512-1JH4FliKQ3trkMD17X+bKGsph5TsiM+AiiqnVKr1wxA/GoUSDHiWG/zROzLAbDIA7eclBCjQsp8hrBEJk7LRUQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pkcs9": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
-			"integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.0.tgz",
+			"integrity": "sha512-igArY6bpCI6tOPm2EU9QPrXuKq2s1iraLCTym4UlooYdzcRDIPCRUN9TAEcqZ5rZhA+HiPdFKTbDP9vneN/tsg==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-cms": "^2.8.0",
-				"@peculiar/asn1-pfx": "^2.8.0",
-				"@peculiar/asn1-pkcs8": "^2.8.0",
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
-				"@peculiar/asn1-x509-attr": "^2.8.0",
+				"@peculiar/asn1-cms": "^2.9.0",
+				"@peculiar/asn1-pfx": "^2.9.0",
+				"@peculiar/asn1-pkcs8": "^2.9.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
+				"@peculiar/asn1-x509-attr": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-rsa": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
-			"integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.0.tgz",
+			"integrity": "sha512-vOD7Q4UmQWhlMYuWJawS2sD+/JcPKJNtyQuFZx09r+KFhm5/HxfGak63y/m56cpBjmb5k6PeRlQf1fvLQAieUA==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-schema": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-			"integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.0.tgz",
+			"integrity": "sha512-AKvPMOM7LfK0uFe1m7o7+veOa8xQGPqsqOrKi3QKgCElzwjGp39mbhr2g7mt/v/mXQHiIvJmDj5cJS173x8Q9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/utils": "^2.0.2",
@@ -2012,25 +2752,25 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-x509": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
-			"integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.0.tgz",
+			"integrity": "sha512-b9Na83rhRFQBd5CuMmuEqokYhmyWUbG7mNZl/thGhBwLpCdiZ85TZ3WFhF7OVgOekC5uKhLk4C3HKtdiScCMdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
 				"@peculiar/utils": "^2.0.2",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-x509-attr": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
-			"integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.0.tgz",
+			"integrity": "sha512-f+u+EyGjfPvPzvr0+rlh/TFEO7LWt84mEwQynCUYr4F6urf/8s6+ESJ23qfSn1aamkZR6AuBNaC62iEsGvp0+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.8.0",
-				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.9.0",
+				"@peculiar/asn1-x509": "^2.9.0",
 				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
@@ -3462,14 +4202,14 @@
 			}
 		},
 		"node_modules/@tanstack/react-router": {
-			"version": "1.170.27",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.27.tgz",
-			"integrity": "sha512-Hxl49xzd8ffWd2ZMigqfXZmpySpixWGvjq5zfh2nK2DbzzDH6IGVh+iUuwarK9MJNcnhWPZ85tOoy6o/OmNlww==",
+			"version": "1.170.28",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.28.tgz",
+			"integrity": "sha512-62GU/aV27w1O663K4L01+N5zw4hqwT5Gvq+nMG34ISxQlCgVCBxXff3IscZn2d/tUktnxc9USAdCcdWh00Oi/w==",
 			"license": "MIT",
 			"dependencies": {
 				"@tanstack/history": "1.162.1",
 				"@tanstack/react-store": "^0.9.3",
-				"@tanstack/router-core": "1.171.22",
+				"@tanstack/router-core": "1.171.23",
 				"isbot": "^5.1.22"
 			},
 			"engines": {
@@ -3536,19 +4276,19 @@
 			}
 		},
 		"node_modules/@tanstack/react-start": {
-			"version": "1.168.44",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.168.44.tgz",
-			"integrity": "sha512-varBaGENYuX0qdRMy8xZvr3BpHCHfkOeBaFCQkXUaOzK3NmWdpqj6CSbPq5uMCHkvFTDXNN6PZukp5zRa5Wmcg==",
+			"version": "1.168.45",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.168.45.tgz",
+			"integrity": "sha512-WOCLJvIwIJpWJXbHv2rQn6i9qbUTirxSBwvtrfBOVI9umgjN72GM4Gr4w25I2DIDdlva1mRP/u9DkIEZVsAnVw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/react-router": "1.170.27",
-				"@tanstack/react-start-client": "1.168.25",
-				"@tanstack/react-start-rsc": "0.1.43",
-				"@tanstack/react-start-server": "1.167.32",
+				"@tanstack/react-router": "1.170.28",
+				"@tanstack/react-start-client": "1.168.26",
+				"@tanstack/react-start-rsc": "0.1.44",
+				"@tanstack/react-start-server": "1.167.33",
 				"@tanstack/router-utils": "1.162.2",
-				"@tanstack/start-client-core": "1.170.22",
-				"@tanstack/start-plugin-core": "1.171.34",
-				"@tanstack/start-server-core": "1.169.26",
+				"@tanstack/start-client-core": "1.170.23",
+				"@tanstack/start-plugin-core": "1.171.35",
+				"@tanstack/start-server-core": "1.169.27",
 				"pathe": "^2.0.3"
 			},
 			"engines": {
@@ -3577,14 +4317,14 @@
 			}
 		},
 		"node_modules/@tanstack/react-start-client": {
-			"version": "1.168.25",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-start-client/-/react-start-client-1.168.25.tgz",
-			"integrity": "sha512-vwjhuXUXFEAS8btmmXa24J/cP12AuAqIn/9OdZnrVufBE489IaxUEE3KuqEyUyZ+dtwPxChgVxFPHLcG9zonwA==",
+			"version": "1.168.26",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-start-client/-/react-start-client-1.168.26.tgz",
+			"integrity": "sha512-Ev+5Nrl3UEPn7qLFrgnLZ/MDaSecXuUjfJfnMVxk1fa2jNaC+bosrhm9JedvCuUJ8rtdCx4QOzy3ha9dgu73gA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/react-router": "1.170.27",
-				"@tanstack/router-core": "1.171.22",
-				"@tanstack/start-client-core": "1.170.22"
+				"@tanstack/react-router": "1.170.28",
+				"@tanstack/router-core": "1.171.23",
+				"@tanstack/start-client-core": "1.170.23"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -3599,18 +4339,18 @@
 			}
 		},
 		"node_modules/@tanstack/react-start-rsc": {
-			"version": "0.1.43",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-start-rsc/-/react-start-rsc-0.1.43.tgz",
-			"integrity": "sha512-5h5qytaTlhakTWX0oMz7pVxS/4FuCJeg5a/jKkbLsEU2hWy/R098zQG9tftkWbzPhq+B3pfrGk32ufUzsiwK5A==",
+			"version": "0.1.44",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-start-rsc/-/react-start-rsc-0.1.44.tgz",
+			"integrity": "sha512-0XD9tAGcL3vlK2PHvjxkrqmE4SUExaIy14e60EARYYoTxZgL0JucKyMkVK3k+GBlrJ0jSrAnvD0gB/gWMN+S9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/react-router": "1.170.27",
-				"@tanstack/router-core": "1.171.22",
+				"@tanstack/react-router": "1.170.28",
+				"@tanstack/router-core": "1.171.23",
 				"@tanstack/router-utils": "1.162.2",
-				"@tanstack/start-client-core": "1.170.22",
+				"@tanstack/start-client-core": "1.170.23",
 				"@tanstack/start-fn-stubs": "1.162.0",
-				"@tanstack/start-plugin-core": "1.171.34",
-				"@tanstack/start-storage-context": "1.167.24",
+				"@tanstack/start-plugin-core": "1.171.35",
+				"@tanstack/start-storage-context": "1.167.25",
 				"pathe": "^2.0.3"
 			},
 			"engines": {
@@ -3640,14 +4380,14 @@
 			}
 		},
 		"node_modules/@tanstack/react-start-server": {
-			"version": "1.167.32",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-start-server/-/react-start-server-1.167.32.tgz",
-			"integrity": "sha512-HZV8EE9f2XU+KnyJcB20SCZgAm6G3uGPUwihaqgAz+MPnuJ/xG1iNy1oyQRz/SeqI3PVnPKzWK3Dkv+7xiO7cA==",
+			"version": "1.167.33",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-start-server/-/react-start-server-1.167.33.tgz",
+			"integrity": "sha512-N7/4x6NBikEyg727oyqfJcr4QaiTwV7Fe9uu8vLNLm1BmC9b5TJkFqrluA0igIhL2VKvjqbdtQ7AGQ+G3/s3pQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/react-router": "1.170.27",
-				"@tanstack/router-core": "1.171.22",
-				"@tanstack/start-server-core": "1.169.26"
+				"@tanstack/react-router": "1.170.28",
+				"@tanstack/router-core": "1.171.23",
+				"@tanstack/start-server-core": "1.169.27"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -3680,9 +4420,9 @@
 			}
 		},
 		"node_modules/@tanstack/router-core": {
-			"version": "1.171.22",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.22.tgz",
-			"integrity": "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw==",
+			"version": "1.171.23",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.23.tgz",
+			"integrity": "sha512-jdo0oyJ5cj7kz04z7I2hvmWswmqLD+zOGDnT2VZlLk20sQ25vF1QVq5uTVi1Lnp/dlHZtZpAuA7fLJuwy+67/A==",
 			"license": "MIT",
 			"dependencies": {
 				"@tanstack/history": "1.162.1",
@@ -3726,13 +4466,13 @@
 			}
 		},
 		"node_modules/@tanstack/router-generator": {
-			"version": "1.167.28",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.167.28.tgz",
-			"integrity": "sha512-AxvzdqQoBxrA8hoO1fHYg4cAUVug/xLqQhsGbNG1PelU3RbYRYEtDim7+HbYQCOqJaEuvV8tCvrTPTnT69iIwg==",
+			"version": "1.167.29",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.167.29.tgz",
+			"integrity": "sha512-gN2o3M5bEHD7Nxsna4ezcmG0hqS4BQQ2FUNFByan0h2VUtoCFobyvaOd24gVYvGPiw7ENYa/rtAVLub9HMZJqQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.28.5",
-				"@tanstack/router-core": "1.171.22",
+				"@tanstack/router-core": "1.171.23",
 				"@tanstack/router-utils": "1.162.2",
 				"@tanstack/virtual-file-routes": "1.162.0",
 				"jiti": "^2.7.0",
@@ -3749,16 +4489,16 @@
 			}
 		},
 		"node_modules/@tanstack/router-plugin": {
-			"version": "1.168.30",
-			"resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.168.30.tgz",
-			"integrity": "sha512-Z53FeZjSddyn3c+lmUGHOU3bhZPpaFabcynja8/s87CZeyMYS7oNgUMoaYZAhVLk9cAEC/z3fkqISXqktZadDA==",
+			"version": "1.168.31",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.168.31.tgz",
+			"integrity": "sha512-9HyEtUF02QnjORoFugSjtP98rlhGyiI+stPaLHp4eVTRYywYnSao/2cHDo2TblTlz8pptYeQsIX3YjbORVA6vQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.28.5",
 				"@babel/template": "^7.27.2",
 				"@babel/types": "^7.28.5",
-				"@tanstack/router-core": "1.171.22",
-				"@tanstack/router-generator": "1.167.28",
+				"@tanstack/router-core": "1.171.23",
+				"@tanstack/router-generator": "1.167.29",
 				"@tanstack/router-utils": "1.162.2",
 				"chokidar": "^5.0.0",
 				"unplugin": "^3.0.0",
@@ -3773,7 +4513,7 @@
 			},
 			"peerDependencies": {
 				"@rsbuild/core": ">=1.0.2 || ^2.0.0",
-				"@tanstack/react-router": "^1.170.26",
+				"@tanstack/react-router": "^1.170.28",
 				"vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
 				"vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
 				"webpack": ">=5.92.0"
@@ -3837,14 +4577,14 @@
 			}
 		},
 		"node_modules/@tanstack/start-client-core": {
-			"version": "1.170.22",
-			"resolved": "https://registry.npmjs.org/@tanstack/start-client-core/-/start-client-core-1.170.22.tgz",
-			"integrity": "sha512-18gHvhrVLEmhO0qZVIJaR/y3Mb7tvC9UQnCEiooQG/aIpYg4/kqoQ06E7WUJ/0WFy4NZOkEjk8QkDQNkFED+1g==",
+			"version": "1.170.23",
+			"resolved": "https://registry.npmjs.org/@tanstack/start-client-core/-/start-client-core-1.170.23.tgz",
+			"integrity": "sha512-P4IFzE6/Yj0U3HuU3b7GLaNdQmy3+Ksv3/Za4WHi0z+w/H6Z7Ak0oU6ls547gHdxa2vDIh0FzEBwN+2yWla4sA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/router-core": "1.171.22",
+				"@tanstack/router-core": "1.171.23",
 				"@tanstack/start-fn-stubs": "1.162.0",
-				"@tanstack/start-storage-context": "1.167.24",
+				"@tanstack/start-storage-context": "1.167.25",
 				"seroval": "^1.6.2"
 			},
 			"engines": {
@@ -3869,19 +4609,19 @@
 			}
 		},
 		"node_modules/@tanstack/start-plugin-core": {
-			"version": "1.171.34",
-			"resolved": "https://registry.npmjs.org/@tanstack/start-plugin-core/-/start-plugin-core-1.171.34.tgz",
-			"integrity": "sha512-MMp5Mlt8HAtstkVKwHW6dY5w58CP/Vtq+DhXdH4mIPuOeEhFtl/BYErJCzpnq80QqbEpRxCfMZPf9ng2PzApaA==",
+			"version": "1.171.35",
+			"resolved": "https://registry.npmjs.org/@tanstack/start-plugin-core/-/start-plugin-core-1.171.35.tgz",
+			"integrity": "sha512-8K+DIcoo0nFXkXXcMLgQLc1S+bwkU3ZQMq7hGadlAGjMbsGyJFaP5M4Yc8NHa6wuRc0KYjwMLyGuIXemlPAZgw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "7.27.1",
 				"@babel/core": "^7.28.5",
 				"@babel/types": "^7.28.5",
-				"@tanstack/router-core": "1.171.22",
-				"@tanstack/router-generator": "1.167.28",
-				"@tanstack/router-plugin": "1.168.30",
+				"@tanstack/router-core": "1.171.23",
+				"@tanstack/router-generator": "1.167.29",
+				"@tanstack/router-plugin": "1.168.31",
 				"@tanstack/router-utils": "1.162.2",
-				"@tanstack/start-server-core": "1.169.26",
+				"@tanstack/start-server-core": "1.169.27",
 				"exsolve": "^1.0.7",
 				"lightningcss": "^1.32.0",
 				"pathe": "^2.0.3",
@@ -3930,15 +4670,15 @@
 			}
 		},
 		"node_modules/@tanstack/start-server-core": {
-			"version": "1.169.26",
-			"resolved": "https://registry.npmjs.org/@tanstack/start-server-core/-/start-server-core-1.169.26.tgz",
-			"integrity": "sha512-57Pvc00i/Y6l8+kqlV/QElVUh5onFUPeMUBDDRNwelAA4eoOmRDmfEWfVfkJNYlcAF4kt/s0mgnD58DlCgC9JA==",
+			"version": "1.169.27",
+			"resolved": "https://registry.npmjs.org/@tanstack/start-server-core/-/start-server-core-1.169.27.tgz",
+			"integrity": "sha512-pWmHRfqTlk0QQ87AUxb6y9jNjb28d0zRf0Pg5aelv1ePK6j9PLtfZrX1XaC+Zmft5yCoO2NhzVDd97SGd/dBdA==",
 			"license": "MIT",
 			"dependencies": {
 				"@tanstack/history": "1.162.1",
-				"@tanstack/router-core": "1.171.22",
-				"@tanstack/start-client-core": "1.170.22",
-				"@tanstack/start-storage-context": "1.167.24",
+				"@tanstack/router-core": "1.171.23",
+				"@tanstack/start-client-core": "1.170.23",
+				"@tanstack/start-storage-context": "1.167.25",
 				"fetchdts": "^0.1.6",
 				"h3-v2": "npm:h3@2.0.1-rc.20",
 				"seroval": "^1.6.2"
@@ -3952,12 +4692,12 @@
 			}
 		},
 		"node_modules/@tanstack/start-storage-context": {
-			"version": "1.167.24",
-			"resolved": "https://registry.npmjs.org/@tanstack/start-storage-context/-/start-storage-context-1.167.24.tgz",
-			"integrity": "sha512-HPltgydit1LmLJFX3BhMcXMxkmUgtWJopPUx6Eg0YTC4tVwFvUhSWCrfgtTIiGWcHd1Ah+fi6fK9BAe8Y5KZtw==",
+			"version": "1.167.25",
+			"resolved": "https://registry.npmjs.org/@tanstack/start-storage-context/-/start-storage-context-1.167.25.tgz",
+			"integrity": "sha512-uGV7/y6hbzur8HumgGksG7627AJNCkYwWnRwrlx0BAwJoOshub7vMKD9cX28wGZc7CsKRG84+JBqiWH3D7lTCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/router-core": "1.171.22"
+				"@tanstack/router-core": "1.171.23"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -4036,6 +4776,16 @@
 				"@types/react-dom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/aria-query": {
@@ -4772,10 +5522,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.13",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-			"deprecated": "this version has critical issues, please update to the latest version",
+			"version": "0.8.14",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+			"integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5278,9 +6027,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.11.13",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-			"integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+			"version": "2.11.14",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+			"integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -6896,9 +7645,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.405",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
-			"integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+			"version": "1.5.406",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
+			"integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
 			"license": "ISC"
 		},
 		"node_modules/electron-winstaller": {
@@ -9057,9 +9806,9 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/mediabunny": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.53.0.tgz",
-			"integrity": "sha512-RjWe9yJr9MPvb6kX4gSu54fZD2w1yf6RyCS0Jmgaml+fFSqEr7+XuASXoRxSqJxgc+wIe+7TujXWcyj3evJ3Bg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.54.0.tgz",
+			"integrity": "sha512-L7yaV6iS6SYtHAs0FPQsAy1fprwvoX39WqbAD7GaCQVXKj/7zwxlAQkCkL2K52XakuDES8lbRRNpUlGWUOnv8Q==",
 			"license": "MPL-2.0",
 			"workspaces": [
 				".",
@@ -9305,27 +10054,25 @@
 			}
 		},
 		"node_modules/nitro-nightly": {
-			"version": "3.0.1-20260810-113911-16ff2809",
-			"resolved": "https://registry.npmjs.org/nitro-nightly/-/nitro-nightly-3.0.1-20260810-113911-16ff2809.tgz",
-			"integrity": "sha512-CD/oRD6udCLWDMOHRRulls448wD1bUzQ6GYfzlUKXTSERDGML9orZhp0dfXTDMZ0A4EtUkRogFH/vHAj9P42ow==",
+			"version": "3.0.1-alpha.2",
+			"resolved": "https://registry.npmjs.org/nitro-nightly/-/nitro-nightly-3.0.1-alpha.2.tgz",
+			"integrity": "sha512-/Ows8m2X4N+zNNwnG/Vq5sQfSfsjHvppelnrq0jCs0YN73Zakg14jVmH1oKDuEwfnmm57oDPxNMn8BIGgUOT4A==",
 			"license": "MIT",
 			"dependencies": {
 				"consola": "^3.4.2",
-				"crossws": "^0.4.10",
+				"crossws": "^0.4.3",
 				"db0": "^0.3.4",
-				"env-runner": "^0.1.16",
-				"h3": "^2.0.1-rc.25",
-				"h3-rules": "^0.1.0",
-				"hookable": "^6.1.1",
-				"nf3": "^0.3.22",
-				"ocache": "^0.2.0",
+				"h3": "^2.0.1-rc.11",
+				"jiti": "^2.6.1",
+				"nf3": "^0.3.5",
 				"ofetch": "^2.0.0-alpha.3",
 				"ohash": "^2.0.11",
-				"rolldown": "^1.2.0",
-				"rou3": "^0.9.1",
-				"srvx": "^0.11.22",
+				"oxc-minify": "^0.110.0",
+				"oxc-transform": "^0.110.0",
+				"srvx": "^0.10.1",
+				"undici": "^7.18.2",
 				"unenv": "^2.0.0-rc.24",
-				"unstorage": "^2.0.0-alpha.7"
+				"unstorage": "^2.0.0-alpha.5"
 			},
 			"bin": {
 				"nitro": "dist/cli/index.mjs"
@@ -9334,26 +10081,13 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"@vercel/queue": "^0.4.0",
-				"dotenv": "*",
-				"giget": "*",
-				"jiti": "^2.7.0",
-				"rollup": "^4.62.2",
-				"vite": "^7 || ^8",
-				"xml2js": "^0.6.2",
-				"zephyr-agent": "^1.1.2"
+				"rolldown": ">=1.0.0-beta.0",
+				"rollup": "^4",
+				"vite": "^7 || ^8 || >=8.0.0-0",
+				"xml2js": "^0.6.2"
 			},
 			"peerDependenciesMeta": {
-				"@vercel/queue": {
-					"optional": true
-				},
-				"dotenv": {
-					"optional": true
-				},
-				"giget": {
-					"optional": true
-				},
-				"jiti": {
+				"rolldown": {
 					"optional": true
 				},
 				"rollup": {
@@ -9364,45 +10098,30 @@
 				},
 				"xml2js": {
 					"optional": true
-				},
-				"zephyr-agent": {
-					"optional": true
 				}
 			}
 		},
-		"node_modules/nitro-nightly/node_modules/h3-rules": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/h3-rules/-/h3-rules-0.1.0.tgz",
-			"integrity": "sha512-MrUUH1E/yoM7hvpKVbLs/CFeindwiTn7Fcfo+zXDpfuRYbcpJDPkYGGttCSiHNJmjUQNYQ5yn9veUIqFonYXuw==",
-			"license": "MIT",
-			"dependencies": {
-				"rou3": "^0.9.1",
-				"ufo": "^1.6.4"
-			},
-			"peerDependencies": {
-				"h3": "^2.0.1-rc.25",
-				"ocache": ">=0.2.0"
-			},
-			"peerDependenciesMeta": {
-				"ocache": {
-					"optional": true
-				}
+		"node_modules/nitro-nightly/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"extraneous": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
-		"node_modules/nitro-nightly/node_modules/ocache": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ocache/-/ocache-0.2.0.tgz",
-			"integrity": "sha512-QE+SxXf/A8yR01rEOg2X5KwUe+mARHo1xQXl+iwLMzLIH06S5lBOZhhHQWp7T5etfFa8nOnRhvjGuo9YBCWwig==",
+		"node_modules/nitro-nightly/node_modules/srvx": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/srvx/-/srvx-0.10.1.tgz",
+			"integrity": "sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==",
 			"license": "MIT",
-			"dependencies": {
-				"ohash": "^2.0.11"
+			"bin": {
+				"srvx": "bin/srvx.mjs"
+			},
+			"engines": {
+				"node": ">=20.16.0"
 			}
-		},
-		"node_modules/nitro-nightly/node_modules/rou3": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.2.tgz",
-			"integrity": "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==",
-			"license": "MIT"
 		},
 		"node_modules/nitro-nightly/node_modules/unstorage": {
 			"version": "2.0.0-alpha.7",
@@ -9504,6 +10223,16 @@
 				"uploadthing": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/nitro/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"extraneous": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/nitro/node_modules/unstorage": {
@@ -9857,9 +10586,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+			"integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
 			"license": "MIT"
 		},
 		"node_modules/once": {
@@ -9879,6 +10608,74 @@
 			"license": "MIT",
 			"dependencies": {
 				"fn.name": "1.x.x"
+			}
+		},
+		"node_modules/oxc-minify": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.110.0.tgz",
+			"integrity": "sha512-KWGTzPo83QmGrXC4ml83PM9HDwUPtZFfasiclUvTV4i3/0j7xRRqINVkrL77CbQnoWura3CMxkRofjQKVDuhBw==",
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-minify/binding-android-arm-eabi": "0.110.0",
+				"@oxc-minify/binding-android-arm64": "0.110.0",
+				"@oxc-minify/binding-darwin-arm64": "0.110.0",
+				"@oxc-minify/binding-darwin-x64": "0.110.0",
+				"@oxc-minify/binding-freebsd-x64": "0.110.0",
+				"@oxc-minify/binding-linux-arm-gnueabihf": "0.110.0",
+				"@oxc-minify/binding-linux-arm-musleabihf": "0.110.0",
+				"@oxc-minify/binding-linux-arm64-gnu": "0.110.0",
+				"@oxc-minify/binding-linux-arm64-musl": "0.110.0",
+				"@oxc-minify/binding-linux-ppc64-gnu": "0.110.0",
+				"@oxc-minify/binding-linux-riscv64-gnu": "0.110.0",
+				"@oxc-minify/binding-linux-riscv64-musl": "0.110.0",
+				"@oxc-minify/binding-linux-s390x-gnu": "0.110.0",
+				"@oxc-minify/binding-linux-x64-gnu": "0.110.0",
+				"@oxc-minify/binding-linux-x64-musl": "0.110.0",
+				"@oxc-minify/binding-openharmony-arm64": "0.110.0",
+				"@oxc-minify/binding-wasm32-wasi": "0.110.0",
+				"@oxc-minify/binding-win32-arm64-msvc": "0.110.0",
+				"@oxc-minify/binding-win32-ia32-msvc": "0.110.0",
+				"@oxc-minify/binding-win32-x64-msvc": "0.110.0"
+			}
+		},
+		"node_modules/oxc-transform": {
+			"version": "0.110.0",
+			"resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.110.0.tgz",
+			"integrity": "sha512-/fymQNzzUoKZweH0nC5yvbI2eR0yWYusT9TEKDYVgOgYrf9Qmdez9lUFyvxKR9ycx+PTHi/reIOzqf3wkShQsw==",
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-transform/binding-android-arm-eabi": "0.110.0",
+				"@oxc-transform/binding-android-arm64": "0.110.0",
+				"@oxc-transform/binding-darwin-arm64": "0.110.0",
+				"@oxc-transform/binding-darwin-x64": "0.110.0",
+				"@oxc-transform/binding-freebsd-x64": "0.110.0",
+				"@oxc-transform/binding-linux-arm-gnueabihf": "0.110.0",
+				"@oxc-transform/binding-linux-arm-musleabihf": "0.110.0",
+				"@oxc-transform/binding-linux-arm64-gnu": "0.110.0",
+				"@oxc-transform/binding-linux-arm64-musl": "0.110.0",
+				"@oxc-transform/binding-linux-ppc64-gnu": "0.110.0",
+				"@oxc-transform/binding-linux-riscv64-gnu": "0.110.0",
+				"@oxc-transform/binding-linux-riscv64-musl": "0.110.0",
+				"@oxc-transform/binding-linux-s390x-gnu": "0.110.0",
+				"@oxc-transform/binding-linux-x64-gnu": "0.110.0",
+				"@oxc-transform/binding-linux-x64-musl": "0.110.0",
+				"@oxc-transform/binding-openharmony-arm64": "0.110.0",
+				"@oxc-transform/binding-wasm32-wasi": "0.110.0",
+				"@oxc-transform/binding-win32-arm64-msvc": "0.110.0",
+				"@oxc-transform/binding-win32-ia32-msvc": "0.110.0",
+				"@oxc-transform/binding-win32-x64-msvc": "0.110.0"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -11808,9 +12605,7 @@
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
 			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">=20.18.1"
 			}
@@ -12462,6 +13257,20 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-tsconfig-paths/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"extraneous": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/vite/node_modules/lightningcss": {
@@ -13375,6 +14184,30 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xml2js/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/xmlbuilder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
 				"postcss": "^8.5.6",
 				"tailwindcss": "^4.2.4",
 				"tsx": "^4.19.0",
-				"typescript": "^5.7.2",
+				"typescript": "^7.0.2",
 				"vite": "^8.0.10",
 				"vite-tsconfig-paths": "^6.0.2",
 				"vitest": "^3.0.5",
@@ -4320,6 +4320,346 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
@@ -9049,16 +9389,6 @@
 				}
 			}
 		},
-		"node_modules/nitro-nightly/node_modules/lru-cache": {
-			"version": "11.5.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-			"extraneous": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/nitro-nightly/node_modules/ocache": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/ocache/-/ocache-0.2.0.tgz",
@@ -9174,16 +9504,6 @@
 				"uploadthing": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/nitro/node_modules/lru-cache": {
-			"version": "11.5.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-			"extraneous": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
 			}
 		},
 		"node_modules/nitro/node_modules/unstorage": {
@@ -11367,28 +11687,6 @@
 				"utf8-byte-length": "^1.0.1"
 			}
 		},
-		"node_modules/tsconfck": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-			"integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-			"deprecated": "unmaintained",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"tsconfck": "bin/tsconfck.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			},
-			"peerDependencies": {
-				"typescript": "^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11466,17 +11764,38 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+				"tsc": "bin/tsc"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		},
 		"node_modules/ufo": {
@@ -12121,6 +12440,28 @@
 			},
 			"peerDependencies": {
 				"vite": "*"
+			}
+		},
+		"node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+			"integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+			"deprecated": "unmaintained",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tsconfck": "bin/tsconfck.js"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			},
+			"peerDependencies": {
+				"typescript": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vite/node_modules/lightningcss": {
@@ -13034,30 +13375,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/xml2js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/xml2js/node_modules/xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-			"extraneous": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"postcss": "^8.5.6",
 		"tailwindcss": "^4.2.4",
 		"tsx": "^4.19.0",
-		"typescript": "^5.7.2",
+		"typescript": "^7.0.2",
 		"vite": "^8.0.10",
 		"vite-tsconfig-paths": "^6.0.2",
 		"vitest": "^3.0.5",


### PR DESCRIPTION
Closes #381

## What
Bumps `typescript` from `^5.7.2` to `^7.0.0`.

## Why
TS 7.0 (native Go compiler, "Project Corsa") went GA on July 8, 2026 with
typically 8-12x faster full builds. It's a faithful port, not a redesign —
type-checking semantics match 6.0.

## Risk assessment for this repo
- `tsconfig.json` uses `moduleResolution: bundler` + `noEmit: true` — Vite
  does actual transpilation, tsc is type-check only.
- Lint/format is Biome (Rust toolchain), not ESLint/@typescript-eslint, so
  there's no typed-lint plugin depending on the TS compiler API.
- TS 7.0 lacks a stable programmatic compiler API until 7.1 (~Oct 2026), but
  nothing in this stack calls into that API directly, so it doesn't apply here.

## Verification
- [x] `npx tsc --noEmit` — passes, zero errors
- [x] `npm run build` (Vite + Nitro) — passes
- [x] `npm run check` (Biome) — 56 pre-existing errors, confirmed unrelated by
      comparing against TS 5.7.2 via `git stash`
- [x] `npm test` (Vitest) — no test files exist in the repo currently
      (confirmed pre-existing, unrelated to this change)

Scoped narrowly to the TS version bump only — did not touch the pre-existing
Biome errors or missing tests, to keep this reviewable and separate from the
broader dependency cleanup in #362.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript development tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->