### PR TITLE
feat(settings): replace raw URL text with compact truncated copy row

### DIFF
--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -438,7 +438,7 @@ function SettingsPage() {
 											}}
 										>
 											{copied ? <Check size={16} /> : <Copy size={16} />}
-											{copied ? t("settings", "copied") : "Copy"}
+											{copied ? t("settings", "copied") : t("settings", "copy")}
 										</button>
 									</div>
 									{copyError && (

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import QRCode from "qrcode"
 import { useEffect, useState, useRef } from "react"
+import { Copy, Check, Link2 } from "lucide-react"
 import { APP_CONFIG, THEMES } from "../config"
 import serverConfig from "../server-config.json"
 import pkg from "../../package.json"
@@ -387,45 +388,59 @@ function SettingsPage() {
 									</div>
 								)}
 
-								<div className="flex flex-col gap-2 mt-2 w-full px-4 items-center">
-									<button
-										type="button"
-										className="border-0 link-primary link text-lg font-mono bg-base-100 px-4 py-2 rounded-lg inline-block max-w-full overflow-hidden text-ellipsis"
-										onClick={async () => {
-											setCopyError("")
-											try {
-												if (
-													window.isSecureContext &&
-													navigator.clipboard?.writeText
-												) {
-													await navigator.clipboard.writeText(shareUrl)
-												} else if (!copyWithFallback(shareUrl)) {
-													throw new Error("Clipboard copy failed")
-												}
-
-												setCopied(true)
-												if (copyTimerRef.current)
-													clearTimeout(copyTimerRef.current)
-												copyTimerRef.current = setTimeout(() => {
+								<div className="flex flex-col gap-2 mt-2 w-full px-2 items-center">
+									{/* URL row: truncated preview + copy button */}
+									<div className="flex items-center gap-2 w-full bg-base-100 rounded-2xl px-3 py-2">
+										{/* Link icon */}
+										<Link2 size={16} className="shrink-0 opacity-50" />
+										{/* Truncated URL preview — strips the token query param */}
+										<span
+											className="flex-1 font-mono text-sm opacity-80 min-w-0"
+											style={{
+												whiteSpace: "nowrap",
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+											}}
+										>
+											{ip ? `${ip}:${window.location.port}/trackpad` : ""}
+										</span>
+										{/* Copy button */}
+										<button
+											type="button"
+											className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-200 bg-primary/15 text-primary hover:bg-primary/25 active:scale-95"
+											onClick={async () => {
+												setCopyError("")
+												try {
+													if (
+														window.isSecureContext &&
+														navigator.clipboard?.writeText
+													) {
+														await navigator.clipboard.writeText(shareUrl)
+													} else if (!copyWithFallback(shareUrl)) {
+														throw new Error("Clipboard copy failed")
+													}
+													setCopied(true)
+													if (copyTimerRef.current)
+														clearTimeout(copyTimerRef.current)
+													copyTimerRef.current = setTimeout(() => {
+														setCopied(false)
+														copyTimerRef.current = null
+													}, 1500)
+												} catch (err) {
+													console.error("Failed to copy URL:", err)
+													if (copyTimerRef.current) {
+														clearTimeout(copyTimerRef.current)
+														copyTimerRef.current = null
+													}
 													setCopied(false)
-													copyTimerRef.current = null
-												}, 2000)
-											} catch (err) {
-												console.error("Failed to copy URL:", err)
-												if (copyTimerRef.current) {
-													clearTimeout(copyTimerRef.current)
-													copyTimerRef.current = null
+													setCopyError(t("settings", "copyFailed"))
 												}
-												setCopied(false)
-												setCopyError(t("settings", "copyFailed"))
-											}
-										}}
-									>
-										{shareUrl.replace(`${protocol}//`, "")}
-									</button>
-									<p className={`${copied ? "visible" : "invisible"}`}>
-										{t("settings", "copied")}
-									</p>
+											}}
+										>
+											{copied ? <Check size={16} /> : <Copy size={16} />}
+											{copied ? t("settings", "copied") : "Copy"}
+										</button>
+									</div>
 									{copyError && (
 										<p className="text-error text-xs text-center max-w-xs">
 											{copyError}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -5,6 +5,7 @@
 export const i18n = {
 	en: {
 		settings: {
+			copy: "Copy",
 			copied: "Copied to Clipboard!",
 			appVersion: "Rein Remote v{version}",
 			copyFailed:


### PR DESCRIPTION
## Summary

Replaces the multi-line raw connection URL text in the **Connect Mobile** card (Settings page) with a clean, single-line pill row containing a truncated URL preview and a dedicated copy button.

## Problem

The full connection URL (including auth token) was displayed as plain wrapped text below the QR code, often spanning 3+ lines and looking cluttered — especially on narrow cards.

## Changes

- Removed the old full-width `<button>` that displayed the raw URL as wrapping text
- Added a pill-shaped row (`bg-base-100 rounded-2xl`) with:
  - A `Link2` icon on the left as a visual URL indicator
  - A truncated `host:port/trackpad` preview with `text-overflow: ellipsis` (token is **not** shown in preview)
  - A **Copy** button on the right that copies the full `shareUrl` (including token) to clipboard
- Copy button icon swaps from `Copy` → `Check` for 1.5s on success, then reverts
- Error message still shown below on clipboard failure
- Styled with `bg-primary/15 text-primary` — DaisyUI semantic tokens that adapt automatically to both themes

## Theme Behavior

Uses DaisyUI `primary` color token — no separate dark/light conditional logic needed.

#### Dark
<img width="1920" height="1020" alt="Screenshot 2026-08-30 183845" src="https://github.com/user-attachments/assets/3ec22b03-dcb5-44b5-8abf-309d5ed801f5" />

#### Light
<img width="1920" height="1020" alt="Screenshot 2026-08-30 183856" src="https://github.com/user-attachments/assets/2a75e23c-1e7f-4314-994b-ef6953ea9691" />


## Closes #391 

## Checklist

- [x] `npm run check` passes with 0 errors
- [x] No unrelated code touched (other settings fields, WebRTC, drivers untouched)
- [x] Reuses existing `copied` state, `copyTimerRef`, and `copyWithFallback`
- [x] Full `shareUrl` (with token) copied to clipboard; token not visible in UI preview
- [x] Works in both dark (Dracula) and light (Cupcake) themes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Redesigned the “Connect Mobile” share URL row with a cleaner, truncated URL preview.
  - Added a dedicated copy button with visual confirmation after successfully copying the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->